### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+   install:
+   - requirements: requirements/docs.txt


### PR DESCRIPTION
This file is required for Read The Docs™ to create the documentation site automatically.

I am following steps from the Read The Docs import manual tool.

![image](https://github.com/user-attachments/assets/56e36b84-8699-4dc6-aa3c-2e36c35b1af9)
