### PR TITLE
Add the correct installation lib

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Installation
 
 Install from pypi::
 
-    python -m pip install extended-mypy-django-plugin
+    python -m pip install django-pg-migration-tools
 
 .. toctree::
    :maxdepth: 3


### PR DESCRIPTION
This has been a ctrl+c/ctrl+v oversight. We all love the extended mypy plug in but that's not quite like we're installing here!