### PR TITLE
Do not migrate if the router check does not pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
-adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2024-08-23
+
+- Fixes a bug where the `SaferAddIndexConcurrently` class would try to perform
+  a migration regardless of whether the router would allow it (through
+  `router.allow_migrate`).
 
 ## [0.1.1] - 2024-08-14
 

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -6,7 +6,7 @@ Provides custom migration operations that help developers perform idempotent and
 Class Definitions
 -----------------
 
-.. py:class:: SaferAddIndexConcurrently(model_name: str, index: models.Index)
+.. py:class:: SaferAddIndexConcurrently(model_name: str, index: models.Index, hints: Any = None)
 
     Performs CREATE INDEX CONCURRENTLY IF NOT EXISTS without a lock_timeout
     value to guarantee the index creation won't be affected by any pre-set
@@ -16,6 +16,8 @@ Class Definitions
     :type model_name: str
     :param index: Any type of index supported by Django.
     :type index: models.Index
+    :param hints: Hints to be passed to the router as per https://docs.djangoproject.com/en/5.1/topics/db/multi-db/#hints
+    :type hints: Any
 
     **Why use this SaferAddIndexConcurrently operation?**
     -----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ where = ["src"]
 
 [project]
 name = "django_pg_migration_tools"
-version = "0.1.1"
+version = "0.1.2"
 description = "Tools for making Django migrations safer and more scalable."
 license.file = "LICENSE"
 readme = "README.md"


### PR DESCRIPTION
Prior to this change, we weren't checking if the database router allowed the migration to proceed.

We thus add the router.allow_migrate() check, which is the same that the RunSQL operation runs internally. Ref:

- https://github.com/django/django/blob/7adb6dd98d50a238f3eca8c15b16b5aec12575fd/django/db/migrations/operations/special.py#L105

A possible error that would raise before this fix happens when the Django applicatoin has multiple databases and the migration should be routed to only apply on a particular database.