### PR TITLE
Workflow for tracking coverage

### DIFF
--- a/.github/workflows/coverage_comment.yaml
+++ b/.github/workflows/coverage_comment.yaml
@@ -1,0 +1,57 @@
+name: Comment Coverage Report
+
+on: pull_request
+
+env:
+  REPORT_PATH: /tmp/coverage_report
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    services:
+      postgres:
+        image: "postgres:16"
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python versions
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements/*.txt
+
+      - name: Make a virtualenv
+        run: python3 -m venv .venv
+
+      - name: Install requirements
+        run: |
+          source .venv/bin/activate
+          pip install uv==0.1.40
+          make install_python_packages
+
+      - name: Run coverage
+        run: |
+          source .venv/bin/activate
+          make coverage_run
+          echo "## Coverage Report Results" > $REPORT_PATH
+          COVERAGE_FORMAT=markdown make --quiet coverage_report >> $REPORT_PATH
+
+      - name: Comment PR with coverage report
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: /tmp/coverage_report
+          comment_tag: pr_comment

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,5 +62,3 @@ jobs:
         run: |
           source .venv/bin/activate
           nox
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost/django_integrity

--- a/makefile
+++ b/makefile
@@ -5,6 +5,9 @@ SHELL=/bin/bash
 help:
 	@echo "Available targets:"
 	@echo "  clean: Remove all build artifacts at the build/ directory."
+	@echo "  coverage: Run code coverage and print results."
+	@echo "  coverage_report: Only report on already computed coverage results."
+	@echo "  coverage_run: Only run code coverage and store results."
 	@echo "  dev: Install dev dependencies."
 	@echo "  docs: Build the docs at the build/ directory"
 	@echo "  help: Show this help message."
@@ -22,6 +25,20 @@ dev: install_python_packages .git/hooks/pre-commit
 .PHONY:test
 test:
 	python -m pytest $(PYTEST_FLAGS)
+
+.PHONY:coverage_run
+coverage_run:
+	coverage run --branch \
+	--include=src/django_pg_migration_tools/* \
+	--data-file=build/coverage \
+	-m pytest
+
+.PHONY:coverage_report
+coverage_report:
+	coverage report --format=$(COVERAGE_FORMAT) --data-file=build/coverage
+
+.PHONY:coverage
+coverage: coverage_run coverage_report
 
 .PHONY:matrix_test
 matrix_test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ docs = "https://django-pg-migration-tools.readthedocs.io/"
 # Used for running the test matrix via `nox` locally or by remote checks.
 # Also reused in the `dev` dependencies list.
 pytest-in-nox = [
+    "coverage>=7.6.1",
     "dj-database-url>=2.1.0",
     "django-stubs>=5.0.0",
     "environs>=11.0.0",

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -20,6 +20,8 @@ charset-normalizer==3.3.2
     # via requests
 colorlog==6.8.2
     # via nox
+coverage==7.6.1
+    # via django-pg-migration-tools (pyproject.toml)
 distlib==0.3.8
     # via virtualenv
 dj-database-url==2.2.0

--- a/requirements/pytest-in-nox.txt
+++ b/requirements/pytest-in-nox.txt
@@ -8,6 +8,8 @@ asgiref==3.8.1
     #   django-stubs
 colorlog==6.8.2
     # via nox
+coverage==7.6.1
+    # via django-pg-migration-tools (pyproject.toml)
 distlib==0.3.8
     # via virtualenv
 dj-database-url==2.2.0


### PR DESCRIPTION
# GitHub Workflow For Printing Coverage Result

This PR adds a new GitHub Workflow that uses the `coverage` package (from Pypi) to run reports on the testing coverage.

This code could be swapped for, or enhanced by, a [codecov subscription](https://about.codecov.io/) in future.