### PR TITLE
SaferRemoveIndexConcurrently

### DIFF
--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -109,3 +109,97 @@ Class Definitions
                   index=models.Index(fields=["foo"], name="foo_idx"),
               ),
           ]
+
+
+
+.. py:class:: SaferRemoveIndexConcurrently(model_name: str, name: str)
+
+    Performs DROP INDEX CONCURRENTLY IF EXISTS without a lock_timeout
+    value to guarantee the index removal won't be affected by any pre-set
+    value of lock_timeout.
+
+    :param model_name: Model name in lowercase without underscores.
+    :type model_name: str
+    :param name: The name of the index to be deleted.
+    :type name: str
+
+    **Why use SaferRemoveIndexConcurrently?**
+    -----------------------------------------
+
+    Django already provides its own ``RemoveIndexConcurrently`` class, which is
+    available through *django.contrib.postres.operations*.
+
+    Django's operation performs a naive:
+
+    .. code-block:: sql
+
+      DROP INDEX CONCURRENTLY IF EXISTS <idx_name>;
+
+    Which has a few problems:
+
+    1. It might time out if an existing value of lock_timeout is pre-set.
+    2. If the operation started but failed because of a lock_timeout error,
+       the existing index won't be removed and it will be marked as INVALID.
+
+    Point 2. is usually not widely known. Even with the CONCURRENTLY
+    condition, the index removal needs to wait on locks, potentially being
+    interrupted by a lock_timeout thus leaving the existing index marked as
+    INVALID.
+
+    This custom ``SaferRemoveIndexConcurrently`` operation addresses theses
+    problems by running the following operations:
+
+    .. code-block:: sql
+
+      -- Necessary so that we can reset the value later.
+      SHOW lock_timeout;
+      -- Necessary to avoid lock timeouts. This is a safe operation as
+      -- DROP INDEX CONCURRENTLY does not lock concurrent selects, inserts,
+      -- updates, or deletes.
+      SET lock_timeout = 0;
+      -- Drop the index
+      DROP INDEX CONCURRENTLY IF EXISTS foo_idx;
+      -- Reset lock_timeout to its original value ("1s" as an example).
+      SET lock_timeout = '1s';
+
+    How to use
+    ----------
+
+    1. Remove the index from the relevant model:
+
+    .. code-block:: diff
+
+          class Meta:
+              indexes = (
+      -           # Existing index being removed.
+      -           models.Index(fields=["foo"], name="foo_idx"),
+                  # Another existing index not being removed.
+                  models.Index(fields=["bar"], name="bar_idx"),
+
+    2. Make the new migration:
+
+    .. code-block:: bash
+
+      ./manage.py makemigrations
+
+    3. Swap the ``RemoveIndex`` class for ``SaferRemoveIndexConcurrently``.
+    Remember to use a non-atomic migration.
+
+    .. code-block:: diff
+
+      + from django_pg_migration_tools import operations
+      from django.db import migrations, models
+
+
+      class Migration(migrations.Migration):
+      +   atomic = False
+
+          dependencies = [("myapp", "0042_dependency")]
+
+          operations = [
+      -        migrations.RemoveIndex(
+      +        operations.SaferRemoveIndexConcurrently(
+                  model_name="mymodel",
+                  name="foo_idx",
+              ),
+          ]

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -6,7 +6,7 @@ Provides custom migration operations that help developers perform idempotent and
 Class Definitions
 -----------------
 
-.. py:class:: SaferAddIndexConcurrently(model_name: str, index: models.Index, hints: Any = None)
+.. py:class:: SaferAddIndexConcurrently(model_name: str, index: models.Index)
 
     Performs CREATE INDEX CONCURRENTLY IF NOT EXISTS without a lock_timeout
     value to guarantee the index creation won't be affected by any pre-set
@@ -16,8 +16,6 @@ Class Definitions
     :type model_name: str
     :param index: Any type of index supported by Django.
     :type index: models.Index
-    :param hints: Hints to be passed to the router as per https://docs.djangoproject.com/en/5.1/topics/db/multi-db/#hints
-    :type hints: Any
 
     **Why use this SaferAddIndexConcurrently operation?**
     -----------------------------------------------------

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -14,7 +14,7 @@ from django.db.models import Index
 from django.test import override_settings, utils
 
 from django_pg_migration_tools import operations
-from tests.example_app.models import IntModel
+from tests.example_app.models import CharModel, IntModel
 
 
 _CHECK_INDEX_EXISTS_QUERY = """
@@ -258,5 +258,172 @@ class TestSaferAddIndexConcurrently:
         with connection.cursor() as cursor:
             cursor.execute(
                 _CHECK_INVALID_INDEX_EXISTS_QUERY, {"index_name": "int_field_idx"}
+            )
+            assert cursor.fetchone()
+
+
+class TestSaferRemoveIndexConcurrently:
+    app_label = "example_app"
+
+    @pytest.mark.django_db
+    def test_requires_atomic_false(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+        operation = operations.SaferRemoveIndexConcurrently(
+            "charmodel", name="char_field_idx"
+        )
+        with pytest.raises(NotSupportedError):
+            with connection.schema_editor(atomic=True) as editor:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+    # Disable the overall test transaction because a concurrent index operation
+    # cannot be triggered/tested inside of a transaction.
+    @pytest.mark.django_db(transaction=True)
+    def test_remove(self):
+        with connection.cursor() as cursor:
+            # Set the lock_timeout to check it has been returned to
+            # its original value once the index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        # Prove that the index exists before running the removal operation.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {"table_name": "example_app_charmodel", "index_name": "char_field_idx"},
+            )
+            assert cursor.fetchone()
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        # Verify that the current state has the index we're about to delete.
+        assert (
+            len(project_state.models[self.app_label, "charmodel"].options["indexes"])
+            == 1
+        )
+        assert (
+            project_state.models[self.app_label, "charmodel"].options["indexes"][0].name
+            == "char_field_idx"
+        )
+
+        # Set the operation that will drop the index concurrently without lock
+        # timeouts.
+        operation = operations.SaferRemoveIndexConcurrently(
+            model_name="charmodel", name="char_field_idx"
+        )
+
+        assert operation.describe() == (
+            "Concurrently removes index char_field_idx on model charmodel "
+            "if the index exists. NOTE: Using django_pg_migration_tools "
+            "SaferRemoveIndexConcurrently operation."
+        )
+
+        name, args, kwargs = operation.deconstruct()
+        assert name == "SaferRemoveIndexConcurrently"
+        assert args == []
+        assert kwargs == {"model_name": "charmodel", "name": "char_field_idx"}
+
+        # Verify that the index will be removed from the django project state
+        # when we run the operation forwards. This is different from actually
+        # removing the index from the db.
+        operation.state_forwards(self.app_label, new_state)
+        assert (
+            len(new_state.models[self.app_label, "charmodel"].options["indexes"]) == 0
+        )
+
+        # Proceed to remove the index:
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Prove that the index doesn't exist in the db anymore.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {"table_name": "example_app_charmodel", "index_name": "char_field_idx"},
+            )
+            assert cursor.fetchone() is None
+
+        # Prove that the lock_timeout has been set back to the default (1s)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                operations.SaferRemoveIndexConcurrently.SHOW_LOCK_TIMEOUT_QUERY
+            )
+            assert cursor.fetchone()[0] == "1s"
+
+        # Assert on the sequence of expected SQL queries:
+        assert queries[0]["sql"] == "SHOW lock_timeout;"
+        assert queries[1]["sql"] == "SET lock_timeout = 0;"
+        assert queries[2]["sql"] == 'DROP INDEX CONCURRENTLY IF EXISTS "char_field_idx"'
+        assert queries[3]["sql"] == "SET lock_timeout = '1s';"
+
+        # Reverse the migration to re-create the index and verify that the
+        # lock_timeout queries are correct.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, new_state, project_state
+                )
+
+        assert reverse_queries[0]["sql"] == "SHOW lock_timeout;"
+        assert reverse_queries[1]["sql"] == "SET lock_timeout = 0;"
+        assert reverse_queries[2]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'char_field_idx'
+            );
+            """)
+        assert (
+            reverse_queries[3]["sql"]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "char_field_idx" ON "example_app_charmodel" ("char_field")'
+        )
+        assert reverse_queries[4]["sql"] == "SET lock_timeout = '1s';"
+
+    # Disable the overall test transaction because a concurrent index cannot
+    # be triggered/tested inside of a transaction.
+    @pytest.mark.django_db(transaction=True)
+    @override_settings(DATABASE_ROUTERS=[NeverAllow()])
+    def test_when_not_allowed_to_migrate(self):
+        # Prove that the index exists before running the removal operation.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {"table_name": "example_app_charmodel", "index_name": "char_field_idx"},
+            )
+            assert cursor.fetchone()
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveIndexConcurrently(
+            "charmodel",
+            "char_field_idx",
+        )
+        # Proceed to try and remove the index:
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # No queries have run, because the migration wasn't allowed to run by
+        # the router.
+        assert len(queries) == 0
+
+        # Make sure the index is still there and hasn't been removed.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {"table_name": "example_app_charmodel", "index_name": "char_field_idx"},
             )
             assert cursor.fetchone()

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -3,3 +3,10 @@ from django.db import models
 
 class IntModel(models.Model):
     int_field = models.IntegerField(default=0)
+
+
+class CharModel(models.Model):
+    char_field = models.CharField(default="char")
+
+    class Meta:
+        indexes = (models.Index(fields=["char_field"], name="char_field_idx"),)


### PR DESCRIPTION
# Description

Adds a new Django migration operation class `SaferRemoveIndexConcurrently`. The name is self-explanatory, but here's a screenshot of the documentation (built with `make docs`) with more details (also available in the diff on the ante-penultimate commit).

![image](https://github.com/user-attachments/assets/2790760f-737a-40dd-bd1a-f1410bcb6c0f)
