### PR TITLE
Add Edit On Github button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,3 +15,10 @@ author = "Kraken Tech"
 
 extensions = ["sphinx_rtd_theme"]
 html_theme = "sphinx_rtd_theme"
+
+html_context = {
+    "display_github": True,
+    "github_user": "kraken-tech",
+    "github_repo": "django-pg-migration-tools",
+    "github_version": "main/docs/",
+}


### PR DESCRIPTION
This button should show up at the top-right on the Read The Docs template.

This fixes the problem with the current button showing "View page source" which displays the raw .rst file backing up the page.

## before

![image](https://github.com/user-attachments/assets/8fe414ee-9f94-4a64-a811-8a56f0251533)


## after

![image](https://github.com/user-attachments/assets/4b362e12-5bd2-445d-aac5-f9cef2bec7db)


tested via `make docs`