### PR TITLE
Skip coverage of __init__.py files

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,6 +29,7 @@ test:
 .PHONY:coverage_run
 coverage_run:
 	coverage run --branch \
+	--omit="__init__.py" \
 	--include=src/django_pg_migration_tools/* \
 	--data-file=build/coverage \
 	-m pytest


### PR DESCRIPTION
They are crowding the results.

**Before**:
```
Name                          Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------
__init__.py                   0       0      0      0   100%
management/__init__.py        0       0      0      0   100%
commands/__init__.py          0       0      0      0   100%
*migrate_with_timeouts.py     25      0     10      0   100%
*operations.py                67      0      6      0   100%
*timeouts.py                  73      5     36      2    92%
------------------------------------------------------------
TOTAL                         165      5    52      2    96%
```
**After**:
```
Name                         Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------
*migrate_with_timeouts.py    25      0     10      0   100%
*operations.py               67      0      6      0   100%
*timeouts.py                 73      5     36      2    92%
--------------------------------------------------------------
TOTAL                        165      5    52      2    96%
```