### PR TITLE
Use --skip-empty for coverage report

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,14 +29,13 @@ test:
 .PHONY:coverage_run
 coverage_run:
 	coverage run --branch \
-	--omit="__init__.py" \
 	--include=src/django_pg_migration_tools/* \
 	--data-file=build/coverage \
 	-m pytest
 
 .PHONY:coverage_report
 coverage_report:
-	coverage report --format=$(COVERAGE_FORMAT) --data-file=build/coverage
+	coverage report --skip-empty --format=$(COVERAGE_FORMAT) --data-file=build/coverage
 
 .PHONY:coverage
 coverage: coverage_run coverage_report


### PR DESCRIPTION
This is a better alternative to not running coverage against __init__.py files entirely. This could've been a problem if those files had code in it.