### PR TITLE
Improve coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 PIP_VERSION=24.0
 SHELL=/bin/bash
+COVERAGE_FILE=build/coverage
 
 .PHONY:help
 help:
@@ -30,12 +31,12 @@ test:
 coverage_run:
 	coverage run --branch \
 	--include=src/django_pg_migration_tools/* \
-	--data-file=build/coverage \
+	--data-file=$(COVERAGE_FILE) \
 	-m pytest
 
 .PHONY:coverage_report
 coverage_report:
-	coverage report --skip-empty --format=$(COVERAGE_FORMAT) --data-file=build/coverage
+	coverage report --skip-empty --format=$(COVERAGE_FORMAT) --data-file=$(COVERAGE_FILE)
 
 .PHONY:coverage
 coverage: coverage_run coverage_report

--- a/makefile
+++ b/makefile
@@ -1,12 +1,14 @@
 PIP_VERSION=24.0
 SHELL=/bin/bash
 COVERAGE_FILE=build/coverage
+COVERAGE_HTML_FOLDER=build/coverage_html
 
 .PHONY:help
 help:
 	@echo "Available targets:"
 	@echo "  clean: Remove all build artifacts at the build/ directory."
 	@echo "  coverage: Run code coverage and print results."
+	@echo "  coverage_html: Builds an HTML coverage report and opens it with \$$BROWSER."
 	@echo "  coverage_report: Only report on already computed coverage results."
 	@echo "  coverage_run: Only run code coverage and store results."
 	@echo "  dev: Install dev dependencies."
@@ -40,6 +42,11 @@ coverage_report:
 
 .PHONY:coverage
 coverage: coverage_run coverage_report
+
+.PHONY:coverage_html
+coverage_html: coverage
+	coverage html --data-file=$(COVERAGE_FILE) -d $(COVERAGE_HTML_FOLDER)
+	$$BROWSER $(COVERAGE_HTML_FOLDER)/index.html
 
 .PHONY:matrix_test
 matrix_test:

--- a/tests/django_pg_migration_tools/test_timeouts.py
+++ b/tests/django_pg_migration_tools/test_timeouts.py
@@ -2,9 +2,47 @@ import datetime
 from unittest import mock
 
 import pytest
-from django.db import utils
+from django.db import connection, connections, transaction, utils
+from django.test import utils as test_utils
 
 from django_pg_migration_tools import timeouts
+
+
+class _Leaky:
+    """
+    A context manager that leaks a transaction when it does not exit
+    successfully.
+
+    This simulates a corner-case scenario where a leaky transaction falls
+    through to the `finally` block of the `db.timeouts` context manager.
+
+    This leaky transaction may be in a state of "ABORTED", which means that
+    all subsequent cursor.execute calls will fail.
+
+    This situation happens during a Django migration, as the
+    BaseDatabaseSchemaEditor class is leaky-prone.
+
+    Refer to the code:
+        - https://github.com/django/django/blob/6f7c0a4d66f36c59ae9eafa168b455e462d81901/django/db/backends/base/schema.py#L156-L168
+
+    On line 166, if the command `self.execute` fails, the atomic.__exit__
+    block is never called thus producing the leak.
+    """
+
+    def __enter__(self):
+        self.atomic = transaction.atomic("default")
+        self.atomic.__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        with connection.cursor() as cursor:
+            # This will raise an exception that aborts the transaction
+            # because the IntModel model has `int_field` as required field
+            # and we aren't giving it.
+            cursor.execute("INSERT INTO example_app_intmodel (id) VALUES (%s)", [1])
+        # Note that the code below is never reached, so the atomic
+        # block is never exited, just like what the Django migrator
+        # does!
+        self.atomic.__exit__(exc_type, exc_value, traceback)
 
 
 class TestApplyTimeouts:
@@ -119,4 +157,73 @@ class TestApplyTimeouts:
                 lock_timeout=datetime.timedelta(seconds=1),
                 close_transaction_leak=True,
             ):
+                pass
+
+    @pytest.mark.django_db
+    @mock.patch(
+        "django_pg_migration_tools.timeouts._in_transaction",
+        mock.Mock(return_value=True),
+    )
+    def test_happy_path_when_timeout_is_not_raised(self):
+        with test_utils.CaptureQueriesContext(connections["default"]) as queries:
+            with timeouts.apply_timeouts(
+                using="default",
+                lock_timeout=datetime.timedelta(seconds=1),
+            ):
+                pass
+
+        assert queries[0]["sql"] == "SHOW lock_timeout"
+        assert queries[1]["sql"] == "SET LOCAL lock_timeout = '1000ms'"
+        assert queries[2]["sql"] == "SET LOCAL lock_timeout = '0'"
+
+    # We need control of transactions for this test otherwise we won't be able
+    # to test the SESSION lock_level for the leaky behaviour, which requires us
+    # to be out of a transaction.
+    @pytest.mark.django_db(transaction=True)
+    def test_leave_transaction_leak_open(self):
+        with pytest.raises(timeouts.UnsupportedTimeoutBehaviour):
+            with timeouts.apply_timeouts(
+                using="default",
+                lock_timeout=datetime.timedelta(seconds=44),
+                # We aren't allowing the utility to close the transaction leak
+                # and therefore we raise an unsupported error because we are
+                # inside an aborted transaction.
+                close_transaction_leak=False,
+            ):
+                try:
+                    with _Leaky():
+                        pass
+                except Exception:
+                    # We handle the exception, so that the db.timeouts finally
+                    # block can reach a state where it tries to revert from a
+                    # leaky transaction.
+                    pass
+
+        # We need to manually close the transaction here so that pytest doesn't
+        # blow up. Remember that we created the leak ourselves so we need to
+        # clean up...
+        conn = transaction.get_connection()
+        conn.close()
+        # Open a clean new connection so that pytest can use it for teardown.
+        conn.connect()
+
+    # We need control of transactions for this test otherwise we won't be able
+    # to test the SESSION lock_level for the leaky behaviour, which requires us
+    # to be out of a transaction.
+    @pytest.mark.django_db(transaction=True)
+    def test_close_when_transaction_leak(self):
+        with timeouts.apply_timeouts(
+            using="default",
+            lock_timeout=datetime.timedelta(seconds=44),
+            # This test won't raise an exception because we are closing the
+            # leaky transaction.
+            close_transaction_leak=True,
+        ):
+            try:
+                with _Leaky():
+                    pass
+            except Exception:
+                # We handle the exception, so that the db.timeouts finally
+                # block can reach a state where it tries to revert from a leaky
+                # transaction.
                 pass


### PR DESCRIPTION
This will improve the coverage of the `apply_timeouts`, which is the only module we have with less than 100% coverage.

These changes add three scenarios that were acused by the coverage report of not being run:
    
    1. A happy path when no timeout exceptions are raised.
    2. When the inner code raises a transaction leak and we are allowed to
       close the leaky transaction.
    3. When the inner code raises a transaction leak and we are **NOT**
       allowed to close the leaky transaction.
