### PR TITLE
Use specific exc for too many retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `migrate_with_timeouts` will now raise `MaximumRetriesReached` instead of
+  `CommandError` when the maximum number of retries is reached.
+
 ## [0.1.4] - 2024-10-01
 
 ### Changed

--- a/src/django_pg_migration_tools/management/commands/migrate_with_timeouts.py
+++ b/src/django_pg_migration_tools/management/commands/migrate_with_timeouts.py
@@ -11,6 +11,10 @@ from typing_extensions import Self
 from django_pg_migration_tools import timeouts
 
 
+class MaximumRetriesReached(base.CommandError):
+    pass
+
+
 class Command(DjangoMigrationMC):
     help = (
         "Wrapper around Django's migrate command that sets a lock_timeout "
@@ -111,7 +115,7 @@ class Command(DjangoMigrationMC):
                 retry_strategy.wait()
                 retry_strategy.attempt_callback(exc)
 
-        raise base.CommandError(
+        raise MaximumRetriesReached(
             f"Please consider trying a longer retry configuration or "
             f"investigate whether there were long-running transactions "
             f"during the migration. "

--- a/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
+++ b/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
@@ -139,7 +139,7 @@ class TestMigrateWithTimeoutsCommand:
             timeouts.DBLockTimeoutError("Bang!"),
         ]
         with pytest.raises(
-            base.CommandError,
+            migrate_with_timeouts.MaximumRetriesReached,
             match=(
                 "There were 4 lock timeouts. This happened because "
                 "--lock-timeout-max-retries was set to 3."

--- a/tests/example_app/settings.py
+++ b/tests/example_app/settings.py
@@ -15,6 +15,6 @@ DATABASES = {
 SECRET_KEY = "test-secret-key"
 INSTALLED_APPS = [
     "tests.example_app",
-    "src.django_pg_migration_tools",
+    "django_pg_migration_tools",
 ]
 USE_TZ = True


### PR DESCRIPTION
When we reach the maximum amount of retries we want to raise an specific exception type so that it doesn't get mixed with other CommandError's.