### PR TITLE
Expose migration stdout to RetryState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `migrate_with_timeouts` callbacks can now access the migration stdout via
+  `RetryState.stdout`.
+
 ## [0.1.5] - 2024-10-07
 
 ### Changed


### PR DESCRIPTION
The `migrate_with_timeouts` command can yield control to a callback every time a retry attempt happens.

Prior to this commit, the argument passed to the callback didn't include the stdout.

This prevented callbacks of handling the rich output that Django provides.

This particularly means that retry_callbacks can't understand which migration failed and is now being retried. In turn, the callback can't log or do anything about it.

With these changes, we pass the `io.StringIO` object that is an argument into the migrate command so that callbacks can use it as they wish.

The stdout will include an output like this:

    Operations to perform:
      Apply all migrations: ...
    Running migrations:
      Applying foo.0042_foo... OK
      Applying bar.0777_bar...