### PR TITLE
Add time since the migration started in RetryState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 ### Changed
 
 - `migrate_with_timeouts` callbacks can now access the migration stdout via
-  `RetryState.stdout`.
+  `RetryState.stdout` and the time since the migration started with
+  `RetryState.time_since_start`.
 - Added a new operation `SaferAddUniqueConstraint` that provides a way to
   safely create unique constraints.
 


### PR DESCRIPTION
It's useful to know how long a particular migration has been retrying for.

This commit will expose this information to the RetryState object that is passed to retry callbacks.

This will allow these callbacks to do interesting things such as logging how much time has elapsed since the migration started.