### PR TITLE
Install package in editable mode

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ help:
 	@echo "  coverage_html: Builds an HTML coverage report and opens it with \$$BROWSER."
 	@echo "  coverage_report: Only report on already computed coverage results."
 	@echo "  coverage_run: Only run code coverage and store results."
-	@echo "  dev: Install dev dependencies."
+	@echo "  dev: Install all dev dependencies and this package in editable mode."
 	@echo "  docs: Build the docs at the build/ directory"
 	@echo "  help: Show this help message."
 	@echo "  lint: Run formatters and static analysis checks."
@@ -24,6 +24,7 @@ help:
 
 .PHONY:dev
 dev: install_python_packages .git/hooks/pre-commit
+	uv pip install -e .
 
 .PHONY:test
 test:


### PR DESCRIPTION
For new contributors installing their development environment via `make dev`, this will allow them to perform changes on the repo without reinstalling the package via `pip install .`.

This allows exploration, experimentation, and iterative changes to take place without having to repeat the pip install command too many times.

From the `pip install` man page:

```
-e, --editable <path/url>
      Install a project in editable mode (i.e. setuptools "develop
      mode") from a local project path or a VCS url.

      (environment variable: PIP_EDITABLE)
```

This change addresses: https://github.com/kraken-tech/django-pg-migration-tools/issues/37