### PR TITLE
Safer remove unique constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `SaferRemoveUniqueConstraint` operation was added. This is the complement for
+  `SaferAddUniqueConstraint` - but with the forward and backwards operations
+  swapped.
+
 ## [0.1.7] - 2024-10-09
 
 ### Fixed

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -325,3 +325,74 @@ Class Definitions
                   constraint=models.UniqueConstraint(fields=["foo"], name="foo_unique"),
               ),
           ]
+
+
+.. py:class:: SaferRemoveUniqueConstraint(model_name: str, name: str)
+
+    Provides a way to drop a unique constraint in a safer and idempotent
+    way.
+
+    :param model_name: Model name in lowercase without underscores.
+    :type model_name: str
+    :param name: The constraint name to be deleted.
+    :type name: str
+
+    **Why use this SaferRemoveUniqueConstraint operation?**
+    -------------------------------------------------------
+
+    The operation that Django provides (``RemoveConstraint``) has the
+    following limitations:
+
+    1. The operation fails if the constraint has already been removed.
+    2. When reverting, the alter table statement provided by Django to recreate
+       the constraint will block reads and writes on the table.
+
+    This custom operation fixes those problems by:
+
+    - Having a custom forward operation that will only attempt to drop the
+      constraint if the constraint exists.
+    - Having a custom backward operation that will add the constraint back
+      without blocking any reads/writes by creating a unique index concurrently
+      first and using it to recreate the constraint. This is achieved through
+      the same strategy of py:class:`SaferAddIndexConcurrently`.
+
+    How to use
+    ----------
+
+    1. Remove the unique constraint in the relevant model as you would:
+
+    .. code-block:: diff
+
+           class Meta:
+      -        constraints = (
+      -           models.UniqueConstraint(fields=["foo"], name="foo_unique"),
+      -        )
+
+    2. Make the new migration:
+
+    .. code-block:: bash
+
+      ./manage.py makemigrations
+
+    3. The only changes you need to perform are: (i) swap Django's
+       ``RemoveConstraint`` for this package's ``SaferRemoveUniqueConstraint``
+       operation, and (ii) use a non-atomic migration.
+
+    .. code-block:: diff
+
+      + from django_pg_migration_tools import operations
+      from django.db import migrations
+
+
+      class Migration(migrations.Migration):
+      +   atomic = False
+
+          dependencies = [("myapp", "0042_dependency")]
+
+          operations = [
+      -        migrations.RemoveConstraint(
+      +        operations.SaferRemoveUniqueConstraint(
+                  model_name="mymodel",
+                  name="foo_unique",
+              ),
+          ]

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -177,7 +177,6 @@ class SafeConstraintOperationManager(base_operations.Operation):
             model=model,
             unique=True,
         )
-
         # Django doesn't have a handy flag "using=..." so we need to alter the
         # SQL statement manually. We go from a SQL that looks like this:
         #

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -157,6 +157,10 @@ class SafeConstraintOperationManager(base_operations.Operation):
         model: type[models.Model],
         constraint: models.UniqueConstraint,
     ) -> None:
+        psql_operations.NotInTransactionMixin()._ensure_not_in_transaction(
+            schema_editor
+        )
+
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
             return
 
@@ -199,6 +203,10 @@ class SafeConstraintOperationManager(base_operations.Operation):
         model: type[models.Model],
         constraint: models.UniqueConstraint,
     ) -> None:
+        psql_operations.NotInTransactionMixin()._ensure_not_in_transaction(
+            schema_editor
+        )
+
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
             return
 

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -138,6 +138,119 @@ class SafeIndexOperationManager(
             cursor.execute(IndexQueries.DROP_INDEX.format(index.name))
 
 
+class ConstraintOperationError(Exception):
+    pass
+
+
+class ConstraintAlreadyExists(ConstraintOperationError):
+    pass
+
+
+class SafeConstraintOperationManager(base_operations.Operation):
+    def create_constraint(
+        self,
+        app_label: str,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        from_state: migrations.state.ProjectState,
+        to_state: migrations.state.ProjectState,
+        raise_if_exists: bool,
+        model: type[models.Model],
+        constraint: models.UniqueConstraint,
+    ) -> None:
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not self._can_create_constraint(schema_editor, constraint, raise_if_exists):
+            return
+
+        index = self._get_index_for_constraint(constraint)
+        SafeIndexOperationManager().safer_create_index(
+            app_label=app_label,
+            schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+            index=index,
+            model=model,
+            unique=True,
+        )
+
+        # Django doesn't have a handy flag "using=..." so we need to alter the
+        # SQL statement manually. We go from a SQL that looks like this:
+        #
+        # - ALTER TABLE "table" ADD CONSTRAINT "constraint" UNIQUE ("field")
+        #
+        # Into a SQL that looks like:
+        #
+        # - ALTER TABLE "table" ADD CONSTRAINT "constraint" UNIQUE USING INDEX "idx"
+        base_sql = str(constraint.create_sql(model, schema_editor))
+        alter_table_sql = base_sql.split(" UNIQUE")[0]
+        sql = f'{alter_table_sql} UNIQUE USING INDEX "{index.name}"'
+
+        # Now we can execute the schema change. We have lock timeouts back in
+        # place after creating the index that would prevent this operation from
+        # running for too long if it's blocked by another query. Otherwise,
+        # this operation should actually be quite fast - if it's not blocked -
+        # since we have created the unique index in the previous step.
+        return schema_editor.execute(sql)
+
+    def drop_constraint(
+        self,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        model: type[models.Model],
+        constraint: models.UniqueConstraint,
+    ) -> None:
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not self._constraint_exists(schema_editor, constraint):
+            # Nothing to delete.
+            return
+
+        schema_editor.remove_constraint(model, constraint)
+
+    def _can_create_constraint(
+        self,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        constraint: models.UniqueConstraint,
+        raise_if_exists: bool,
+    ) -> bool:
+        constraint_exists = self._constraint_exists(schema_editor, constraint)
+        if raise_if_exists and constraint_exists:
+            raise ConstraintAlreadyExists(
+                f"Cannot create a constraint with the name "
+                f"{constraint.name} because a constraint of the same "
+                f"name already exists. If you want to skip this operation "
+                f"when the constraint already exists, run the operation "
+                f"with the flag `skip_if_exists=True`."
+            )
+        # We can't re-create a constraint that already exists because the
+        # ALTER TABLE ... ADD CONSTRAINT is not idempotent.
+        return not constraint_exists
+
+    def _get_index_for_constraint(
+        self, constraint: models.UniqueConstraint
+    ) -> models.Index:
+        return models.Index(
+            *constraint.expressions,
+            fields=constraint.fields,
+            name=constraint.name,
+            condition=constraint.condition,
+            opclasses=constraint.opclasses,  # type: ignore[attr-defined]
+        )
+
+    def _constraint_exists(
+        self,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        constraint: models.UniqueConstraint,
+    ) -> bool:
+        cursor = schema_editor.connection.cursor()
+        cursor.execute(
+            ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
+            {"constraint_name": constraint.name},
+        )
+        return bool(cursor.fetchone())
+
+
 class SaferAddIndexConcurrently(psql_operations.AddIndexConcurrently):
     """
     This class inherits the behaviour of:
@@ -246,14 +359,6 @@ class SaferRemoveIndexConcurrently(psql_operations.RemoveIndexConcurrently):
         )
 
 
-class ConstraintOperationError(Exception):
-    pass
-
-
-class ConstraintAlreadyExists(ConstraintOperationError):
-    pass
-
-
 class SaferAddUniqueConstraint(operation_models.AddConstraint):
     model_name: str
     constraint: models.UniqueConstraint
@@ -285,42 +390,15 @@ class SaferAddUniqueConstraint(operation_models.AddConstraint):
         from_state: migrations.state.ProjectState,
         to_state: migrations.state.ProjectState,
     ) -> None:
-        if not self._can_migrate(app_label, schema_editor, from_state):
-            return
-
-        if not self._can_create_constraint(schema_editor):
-            return
-
-        index = self._get_index_for_constraint()
-        model = to_state.apps.get_model(app_label, self.model_name)
-        SafeIndexOperationManager().safer_create_index(
+        SafeConstraintOperationManager().create_constraint(
             app_label=app_label,
             schema_editor=schema_editor,
             from_state=from_state,
             to_state=to_state,
-            index=index,
-            model=model,
-            unique=True,
+            model=to_state.apps.get_model(app_label, self.model_name),
+            raise_if_exists=self.raise_if_exists,
+            constraint=self.constraint,
         )
-
-        # Django doesn't have a handy flag "using=..." so we need to alter the
-        # SQL statement manually. We go from a SQL that looks like this:
-        #
-        # - ALTER TABLE "table" ADD CONSTRAINT "constraint" UNIQUE ("field")
-        #
-        # Into a SQL that looks like:
-        #
-        # - ALTER TABLE "table" ADD CONSTRAINT "constraint" UNIQUE USING INDEX "idx"
-        base_sql = str(self.constraint.create_sql(model, schema_editor))
-        alter_table_sql = base_sql.split(" UNIQUE")[0]
-        sql = f'{alter_table_sql} UNIQUE USING INDEX "{index.name}"'
-
-        # Now we can execute the schema change. We have lock timeouts back in
-        # place after creating the index that would prevent this operation from
-        # running for too long if it's blocked by another query. Otherwise,
-        # this operation should actually be quite fast - if it's not blocked -
-        # since we have created the unique index in the previous step.
-        return schema_editor.execute(sql)
 
     def database_backwards(
         self,
@@ -329,19 +407,10 @@ class SaferAddUniqueConstraint(operation_models.AddConstraint):
         from_state: migrations.state.ProjectState,
         to_state: migrations.state.ProjectState,
     ) -> None:
-        if not self._can_migrate(app_label, schema_editor, from_state):
-            return
-
-        if not self._constraint_exists(schema_editor):
-            # Nothing to delete.
-            return
-
-        # Execute the DDL that will drop the constraint.
-        super().database_backwards(
-            app_label=app_label,
+        SafeConstraintOperationManager().drop_constraint(
             schema_editor=schema_editor,
-            from_state=from_state,
-            to_state=to_state,
+            model=to_state.apps.get_model(app_label, self.model_name),
+            constraint=self.constraint,
         )
 
     def _validate(self) -> None:
@@ -349,52 +418,6 @@ class SaferAddUniqueConstraint(operation_models.AddConstraint):
             raise ValueError(
                 "SaferAddUniqueConstraint only supports the UniqueConstraint class"
             )
-
-    def _constraint_exists(
-        self,
-        schema_editor: base_schema.BaseDatabaseSchemaEditor,
-    ) -> bool:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
-            ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
-            {"constraint_name": self.constraint.name},
-        )
-        return bool(cursor.fetchone())
-
-    def _can_create_constraint(
-        self,
-        schema_editor: base_schema.BaseDatabaseSchemaEditor,
-    ) -> bool:
-        constraint_exists = self._constraint_exists(schema_editor)
-        if self.raise_if_exists and constraint_exists:
-            raise ConstraintAlreadyExists(
-                f"Cannot create a constraint with the name "
-                f"{self.constraint.name} because a constraint of the same "
-                f"name already exists. If you want to skip this operation "
-                f"when the constraint already exists, run the operation "
-                f"with the flag `skip_if_exists=True`."
-            )
-        # We can't re-create a constraint that already exists because the
-        # ALTER TABLE ... ADD CONSTRAINT is not idempotent.
-        return not constraint_exists
-
-    def _get_index_for_constraint(self) -> models.Index:
-        return models.Index(
-            *self.constraint.expressions,
-            fields=self.constraint.fields,
-            name=self.constraint.name,
-            condition=self.constraint.condition,
-            opclasses=self.constraint.opclasses,  # type: ignore[attr-defined]
-        )
-
-    def _can_migrate(
-        self,
-        app_label: str,
-        schema_editor: base_schema.BaseDatabaseSchemaEditor,
-        from_state: migrations.state.ProjectState,
-    ) -> bool:
-        model = from_state.apps.get_model(app_label, self.model_name)
-        return bool(self.allow_migrate_model(schema_editor.connection.alias, model))
 
     def describe(self) -> str:
         return (

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -475,6 +475,13 @@ class TestSaferAddUniqueConstraint:
                     self.app_label, editor, project_state, new_state
                 )
 
+        # Same for backwards.
+        with pytest.raises(NotSupportedError):
+            with connection.schema_editor(atomic=True) as editor:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
     # Disable the overall test transaction because a unique concurrent index
     # cannot be triggered/tested inside of a transaction.
     @pytest.mark.django_db(transaction=True)

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -500,7 +500,7 @@ class TestSaferAddUniqueConstraint:
         # Prove that the constraint does **not** already exist.
         with connection.cursor() as cursor:
             cursor.execute(
-                operations.SaferAddUniqueConstraint._CHECK_EXISTING_CONSTRAINT_QUERY,
+                operations.ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
                 {"constraint_name": "unique_int_field"},
             )
             assert not cursor.fetchone()
@@ -678,7 +678,7 @@ class TestSaferAddUniqueConstraint:
             )
             assert not cursor.fetchone()
             cursor.execute(
-                operations.SaferAddUniqueConstraint._CHECK_EXISTING_CONSTRAINT_QUERY,
+                operations.ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
                 {"constraint_name": "unique_int_field"},
             )
             assert not cursor.fetchone()

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -798,7 +798,7 @@ class TestSaferAddUniqueConstraint:
             )
             assert not cursor.fetchone()
 
-    # Disable the overall test transaction because a unqiue concurrent index
+    # Disable the overall test transaction because a unique concurrent index
     # creation followed by a constraint addition cannot be triggered/tested
     # inside of a transaction.
     @pytest.mark.django_db(transaction=True)
@@ -923,3 +923,214 @@ class TestSaferAddUniqueConstraint:
                     condition=Q(),
                 ),
             )
+
+
+class TestSaferRemoveUniqueConstraint:
+    app_label = "example_app"
+
+    @pytest.mark.django_db
+    def test_requires_atomic_false(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+        operation = operations.SaferRemoveUniqueConstraint(
+            model_name="charmodel",
+            name="unique_char_field",
+        )
+        with pytest.raises(NotSupportedError):
+            with connection.schema_editor(atomic=True) as editor:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Same for backwards.
+        with pytest.raises(NotSupportedError):
+            with connection.schema_editor(atomic=True) as editor:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation(self):
+        # Prove that the constraint exists before the operation removes it.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                operations.ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
+                {"constraint_name": "unique_char_field"},
+            )
+            assert cursor.fetchone()
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveUniqueConstraint(
+            model_name="charmodel",
+            name="unique_char_field",
+        )
+
+        assert operation.describe() == (
+            "Checks if the constraint unique_char_field exists, and if so, removes "
+            "it. If the migration is reversed, it will recreate the constraint "
+            "using a UNIQUE index. NOTE: Using the django_pg_migration_tools "
+            "SaferRemoveIndexConcurrently operation."
+        )
+
+        name, args, kwargs = operation.deconstruct()
+        assert name == "SaferRemoveUniqueConstraint"
+        assert args == []
+        assert kwargs == {"model_name": "charmodel", "name": "unique_char_field"}
+
+        operation.state_forwards(self.app_label, new_state)
+        assert (
+            len(new_state.models[self.app_label, "charmodel"].options["constraints"])
+            == 0
+        )
+
+        # Proceed to remove the constraint.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Prove the constraint is not there any longer.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                operations.ConstraintQueries.CHECK_EXISTING_CONSTRAINT,
+                {"constraint_name": "unique_char_field"},
+            )
+            assert not cursor.fetchone()
+
+        # Assert on the sequence of expected SQL queries:
+        #
+        # 1. Check if the constraint exists.
+        assert queries[0]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'unique_char_field';
+            """)
+        # 2. Remove the constraint.
+        assert queries[1]["sql"] == (
+            'ALTER TABLE "example_app_charmodel" DROP CONSTRAINT "unique_char_field"'
+        )
+        # Nothing else.
+        assert len(queries) == 2
+
+        # Before reversing, set the lock_timeout value so we can observe it
+        # being re-set.
+        with connection.cursor() as cursor:
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        # Reverse the migration to recreate the constraint.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, new_state, project_state
+                )
+
+        # These will be the same as when creating a constraint safely. I.e.,
+        # adding the index concurrently without timeouts, and using this index
+        # to create the constraint.
+        #
+        # 1. Check if the constraint already exists.
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'unique_char_field';
+            """)
+        # 2. Check the original lock_timeout value to be able to restore it
+        # later.
+        assert reverse_queries[1]["sql"] == "SHOW lock_timeout;"
+        # 3. Remove the timeout.
+        assert reverse_queries[2]["sql"] == "SET lock_timeout = '0';"
+        # 4. Verify if the index is invalid.
+        assert reverse_queries[3]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'unique_char_field'
+            );
+            """)
+        # 5. Finally create the index concurrently.
+        assert (
+            reverse_queries[4]["sql"]
+            == 'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_char_field" ON "example_app_charmodel" ("char_field")'
+        )
+        # 6. Set the timeout back to what it was originally.
+        assert reverse_queries[5]["sql"] == "SET lock_timeout = '1s';"
+
+        # 7. Add the table constraint.
+        assert (
+            reverse_queries[6]["sql"]
+            == 'ALTER TABLE "example_app_charmodel" ADD CONSTRAINT "unique_char_field" UNIQUE USING INDEX "unique_char_field"'
+        )
+        # Nothing else.
+        assert len(reverse_queries) == 7
+
+    @pytest.mark.django_db(transaction=True)
+    @override_settings(DATABASE_ROUTERS=[NeverAllow()])
+    def test_when_not_allowed_to_migrate_by_the_router(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveUniqueConstraint(
+            model_name="charmodel",
+            name="unique_char_field",
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # No queries have run, because the migration wasn't allowed to run by
+        # the router.
+        assert len(queries) == 0
+
+        # Try the same for the reverse operation:
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # No queries have run, because the migration wasn't allowed to run by
+        # the router.
+        assert len(queries) == 0
+
+    @pytest.mark.django_db(transaction=True)
+    def test_does_nothing_if_constraint_does_not_exist(self):
+        # Remove the constraint so that the migration becomes a noop.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'ALTER TABLE "example_app_charmodel"'
+                'DROP CONSTRAINT "unique_char_field";'
+            )
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveUniqueConstraint(
+            model_name="charmodel",
+            name="unique_char_field",
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Checks if the constraint already exists.
+        assert queries[0]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'unique_char_field';
+            """)
+        assert len(queries) == 1

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -10,3 +10,6 @@ class CharModel(models.Model):
 
     class Meta:
         indexes = (models.Index(fields=["char_field"], name="char_field_idx"),)
+        constraints = (
+            models.UniqueConstraint(fields=["char_field"], name="unique_char_field"),
+        )


### PR DESCRIPTION
## Description

The objective of this PR is to create a new operation called `SaferRemoveUniqueIndex` that provides the mirrored functionality of `SaferAddUniqueIndex`..

## Why?
One could use Django's default `RemoveConstraint` operation which would perform the following DDL directly:

```sql
ALTER TABLE "table" DROP CONSTRAINT "constraint";
```

And the reverse DDL is:

```sql
ALTER TABLE "table" ADD CONSTRAINT "constraint" UNIQUE ("field");
```

However...
  - Those operations are not idempotent.
  - The reverse operation in particular is extra unsafe. It will block writes and reads.