### PR TITLE
Handle scenario where unique constraint with condition is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where `SaferAddUniqueConstraint` and `SaferRemoveUniqueConstraint` would
+  accept unique constraints with conditions on them, but produce invalid SQL. Unique
+  constraints with conditions are now handled as partial unique indexes, as per the
+  equivalent Django `AddConstraint` and `RemoveConstraint` operations.
+
 ### Added
 
 - `SaferRemoveUniqueConstraint` operation was added. This is the complement for

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -164,10 +164,29 @@ class SafeConstraintOperationManager(base_operations.Operation):
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
             return
 
+        index = self._get_index_for_constraint(constraint)
+
+        if constraint.condition is not None:
+            """
+            Unique constraints with conditions do not exist in postgres.
+
+            As of writing Django handles these as unique indexes with conditions only
+            in the auto generated operation, so we only create the index and finish here
+            """
+            SafeIndexOperationManager().safer_create_index(
+                app_label=app_label,
+                schema_editor=schema_editor,
+                from_state=from_state,
+                to_state=to_state,
+                index=index,
+                model=model,
+                unique=True,
+            )
+            return
+
         if not self._can_create_constraint(schema_editor, constraint, raise_if_exists):
             return
 
-        index = self._get_index_for_constraint(constraint)
         SafeIndexOperationManager().safer_create_index(
             app_label=app_label,
             schema_editor=schema_editor,
@@ -177,6 +196,7 @@ class SafeConstraintOperationManager(base_operations.Operation):
             model=model,
             unique=True,
         )
+
         # Django doesn't have a handy flag "using=..." so we need to alter the
         # SQL statement manually. We go from a SQL that looks like this:
         #
@@ -198,7 +218,10 @@ class SafeConstraintOperationManager(base_operations.Operation):
 
     def drop_constraint(
         self,
+        app_label: str,
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        from_state: migrations.state.ProjectState,
+        to_state: migrations.state.ProjectState,
         model: type[models.Model],
         constraint: models.UniqueConstraint,
     ) -> None:
@@ -207,6 +230,21 @@ class SafeConstraintOperationManager(base_operations.Operation):
         )
 
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if constraint.condition is not None:
+            # If condition is present on the constraint, it would have been created
+            # as an index instead, so index is instead removed
+            index = self._get_index_for_constraint(constraint)
+
+            SafeIndexOperationManager().safer_drop_index(
+                app_label=app_label,
+                schema_editor=schema_editor,
+                from_state=from_state,
+                to_state=to_state,
+                index=index,
+                model=model,
+            )
             return
 
         if not self._constraint_exists(schema_editor, constraint):
@@ -415,7 +453,10 @@ class SaferAddUniqueConstraint(operation_models.AddConstraint):
         to_state: migrations.state.ProjectState,
     ) -> None:
         SafeConstraintOperationManager().drop_constraint(
+            app_label=app_label,
             schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
             model=to_state.apps.get_model(app_label, self.model_name),
             constraint=self.constraint,
         )
@@ -450,7 +491,10 @@ class SaferRemoveUniqueConstraint(operation_models.RemoveConstraint):
         model = from_state.apps.get_model(app_label, self.model_name)
         from_model_state = from_state.models[app_label, self.model_name.lower()]
         SafeConstraintOperationManager().drop_constraint(
+            app_label=app_label,
             schema_editor=schema_editor,
+            from_state=from_state,
+            to_state=to_state,
             model=model,
             constraint=from_model_state.get_constraint_by_name(self.name),
         )

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -14,7 +14,7 @@ from django.db.models import CheckConstraint, Index, Q, UniqueConstraint
 from django.test import override_settings, utils
 
 from django_pg_migration_tools import operations
-from tests.example_app.models import CharModel, IntModel
+from tests.example_app.models import AnotherCharModel, CharModel, IntModel
 
 
 _CHECK_INDEX_EXISTS_QUERY = """
@@ -924,6 +924,117 @@ class TestSaferAddUniqueConstraint:
                 ),
             )
 
+    @pytest.mark.django_db(transaction=True)
+    def test_when_condition_on_constraint_only_creates_index(self):
+        constraint_name = "partial_unique_int_field"
+
+        # Prove that:
+        #   - An invalid index doesn't exist.
+        #   - The constraint/index doesn't exist yet.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_VALID_INDEX_EXISTS_QUERY,
+                {"index_name": constraint_name},
+            )
+            assert not cursor.fetchone()
+            # Also, set the lock_timeout to check it has been returned to
+            # its original value once the unique index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferAddUniqueConstraint(
+            model_name="intmodel",
+            constraint=UniqueConstraint(
+                fields=("int_field",),
+                name=constraint_name,
+                condition=Q(int_field__gte=2),
+            ),
+        )
+        # Proceed to add the unique index followed by the constraint:
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Confirm that exists as index
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {
+                    "table_name": "example_app_intmodel",
+                    "index_name": constraint_name,
+                },
+            )
+            assert cursor.fetchone()
+
+        # Assert on the sequence of expected SQL queries:
+        #
+        # 1. Check the original lock_timeout value to be able to restore it
+        # later.
+        assert queries[0]["sql"] == "SHOW lock_timeout;"
+        # 2. Remove the timeout.
+        assert queries[1]["sql"] == "SET lock_timeout = '0';"
+        # 3. Verify if the index is invalid.
+        assert queries[2]["sql"] == dedent(
+            f"""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = '{constraint_name}'
+            );
+            """
+        )
+        # 4. Finally create the index concurrently.
+        assert (
+            queries[3]["sql"]
+            == f'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "{constraint_name}" ON "example_app_intmodel" ("int_field") WHERE "int_field" >= 2'
+        )
+        # 6. Set the timeout back to what it was originally.
+        assert queries[4]["sql"] == "SET lock_timeout = '1s';"
+
+        # There are no additional queries
+        assert len(queries) == 5
+
+        # Reverse the migration to drop the index and constraint, and verify
+        # that the lock_timeout queries are correct.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # 2. perform the ALTER TABLE.
+        assert reverse_queries[0]["sql"] == "SHOW lock_timeout;"
+
+        # 3. Remove the timeout.
+        assert reverse_queries[1]["sql"] == "SET lock_timeout = '0';"
+        # 4. Verify if the index is invalid.
+        assert (
+            reverse_queries[2]["sql"]
+            == f'DROP INDEX CONCURRENTLY IF EXISTS "{constraint_name}"'
+        )
+
+        assert reverse_queries[3]["sql"] == "SET lock_timeout = '1s';"
+
+        assert len(reverse_queries) == 4
+
+        # Verify the index representing the constraint doesn't exist any more.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_INDEX_EXISTS_QUERY,
+                {
+                    "table_name": "example_app_intmodel",
+                    "index_name": constraint_name,
+                },
+            )
+            assert not cursor.fetchone()
+
 
 class TestSaferRemoveUniqueConstraint:
     app_label = "example_app"
@@ -1069,6 +1180,112 @@ class TestSaferRemoveUniqueConstraint:
         )
         # Nothing else.
         assert len(reverse_queries) == 7
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_where_condition_on_unique_constraint(self):
+        constraint_name = "unique_char_field_with_condition"
+
+        with connection.cursor() as cursor:
+            # Set the lock_timeout to check it has been returned to
+            # its original value once the index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        # Prove that the constraint/index exists before the operation removes it.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_VALID_INDEX_EXISTS_QUERY,
+                {"index_name": constraint_name},
+            )
+            assert cursor.fetchone()
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(AnotherCharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveUniqueConstraint(
+            model_name="anothercharmodel",
+            name=constraint_name,
+        )
+
+        operation.state_forwards(self.app_label, new_state)
+
+        # Proceed to remove the constraint.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # Prove the index is not there any longer.
+        with connection.cursor() as cursor:
+            cursor.execute(
+                _CHECK_VALID_INDEX_EXISTS_QUERY,
+                {"index_name": constraint_name},
+            )
+            assert not cursor.fetchone()
+
+        # Assert on the sequence of expected SQL queries:
+        #
+        # 1. Check the original lock_timeout value to be able to restore it
+        # later.
+        assert queries[0]["sql"] == "SHOW lock_timeout;"
+        # 2. Remove the timeout.
+        assert queries[1]["sql"] == "SET lock_timeout = '0';"
+
+        # 3. Drop the index concurrently.
+        assert (
+            queries[2]["sql"]
+            == f'DROP INDEX CONCURRENTLY IF EXISTS "{constraint_name}"'
+        )
+        # 4. Set the timeout back to what it was originally.
+        assert queries[3]["sql"] == "SET lock_timeout = '1s';"
+
+        assert len(queries) == 4
+
+        # Before reversing, set the lock_timeout value so we can observe it
+        # being re-set.
+        with connection.cursor() as cursor:
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        # Reverse the migration to recreate the constraint.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, new_state, project_state
+                )
+
+        # These will be the same as when creating a constraint safely. I.e.,
+        # adding the index concurrently without timeouts, and using this index
+        # to create the constraint.
+        #
+
+        # 1. Check the original lock_timeout value to be able to restore it
+        # later.
+        assert reverse_queries[0]["sql"] == "SHOW lock_timeout;"
+        # 2. Remove the timeout.
+        assert reverse_queries[1]["sql"] == "SET lock_timeout = '0';"
+        # 3. Verify if the index is invalid.
+        assert reverse_queries[2]["sql"] == dedent(
+            f"""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = '{constraint_name}'
+            );
+            """
+        )
+        # 4. Finally create the index concurrently.
+        assert (
+            reverse_queries[3]["sql"]
+            == f'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "{constraint_name}" ON "example_app_anothercharmodel" ("char_field") WHERE "char_field" IN (\'c\', \'something\')'
+        )
+        # 5. Set the timeout back to what it was originally.
+        assert reverse_queries[4]["sql"] == "SET lock_timeout = '1s';"
+
+        # Nothing else.
+        assert len(reverse_queries) == 5
 
     @pytest.mark.django_db(transaction=True)
     @override_settings(DATABASE_ROUTERS=[NeverAllow()])

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -13,3 +13,17 @@ class CharModel(models.Model):
         constraints = (
             models.UniqueConstraint(fields=["char_field"], name="unique_char_field"),
         )
+
+
+class AnotherCharModel(models.Model):
+    char_field = models.CharField(default="char")
+
+    class Meta:
+        indexes = (models.Index(fields=["char_field"], name="another_char_field_idx"),)
+        constraints = (
+            models.UniqueConstraint(
+                fields=["char_field"],
+                name="unique_char_field_with_condition",
+                condition=models.Q(char_field__in=["c", "something"]),
+            ),
+        )


### PR DESCRIPTION
Postgres does not support unique constraints with conditions, however, Django allows it to be possible to specify a unique constraint with a condition. In postgres, these are represented as unique indexes with conditions instead

Here, we modify the operations to add or remove constraints to align with django operations behaviour - adding or removing the unique index - however with "if exists / not exists" and concurrently added to these.

An example of what is currently generated in Django when using a `migrations.AddConstraint(`

`CREATE UNIQUE INDEX "" ON "" ("") WHERE "status" IN (''ACCEPTED', 'GENERATED', 'STARTED');`