### PR TITLE
Pass in database name to RetryState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Updated
+
+- The `migrate_with_timeouts` callback argument `RetryState` now includes the
+  name of the database that the retry being performed is associated with.
+
 ## [0.1.9] - 2024-11-14
 
 ### Added

--- a/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
+++ b/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
@@ -186,7 +186,7 @@ class TestMigrateWithTimeoutsCommand:
         """
         # Pretend 100 seconds have passed since the migration start and before
         # the callback was called.
-        mock_time.side_effect = [0, 100]
+        mock_time.side_effect = [0.0, 100.0]
 
         def _handle_mock_side_effect(*args: Any, **kwargs: Any) -> None:
             kwargs["stdout"].write(migration_stdout)
@@ -196,7 +196,7 @@ class TestMigrateWithTimeoutsCommand:
 
         # Prove the callback happened by raising the migration stdout and the
         # value of time_since_start in the error message.
-        match = f"migration:{migration_stdout} time_since_start:100"
+        match = f"migration:{migration_stdout} time_since_start:100.0 database:default"
         with pytest.raises(Exception, match=match):
             management.call_command(
                 "migrate_with_timeouts",
@@ -282,5 +282,6 @@ class TestMigrateRetryStrategy:
 def example_callback(retry_state: migrate_with_timeouts.RetryState) -> None:
     raise Exception(
         f"migration:{retry_state.stdout.getvalue()} "
-        f"time_since_start:{retry_state.time_since_start.total_seconds()}"
+        f"time_since_start:{retry_state.time_since_start.total_seconds()} "
+        f"database:{retry_state.database}"
     )


### PR DESCRIPTION
Users with multi-db Django configurations may want to know exactly which
database failed to push the migration forward.

This PR adds a new field called "database" to the RetryState dataclass so
that users who are hooking up onto the retry callback can find that
information.
