### PR TITLE
SaferAddFieldForeignKey operation

### DIFF
--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -502,3 +502,122 @@ Class Definitions
                   field=models.IntegerField()
               ),
           ]
+
+.. py:class:: SaferAddFieldForeignKey(model_name: str, name: str, field: models.ForeignKey)
+
+    Provides a safer way to add a foreign key field to an existing model
+
+    :param model_name: Model name in lowercase without underscores.
+    :type model_name: str
+    :param name: The column name to be set as not null.
+    :type name: str
+    :param field: The foreign key field that is being added.
+    :type field: models.ForeignKey
+
+    **Why use this SaferAddFieldForeignKey operation?**
+    ---------------------------------------------------
+
+    When using Django's default ``AddField`` operation, the SQL created has the
+    following form:
+
+    .. code-block:: sql
+
+      ALTER TABLE "foo" ADD COLUMN "bar_id" bigint NULL
+      REFERENCES "bar" ("id") DEFERRABLE INITIALLY DEFERRED;
+
+      -- optional: if the field doesn't set index=False
+      CREATE INDEX "foo_bar_idx" ON "foo" ("bar_id");
+
+    There are two problems:
+
+    1. The ``ALTER TABLE`` command takes an AccessExclusive lock, which is the
+       highest level of locking. It will block reads and writes on both
+       tables.
+    2. The ``CREATE INDEX`` takes a Share lock which will conflict with
+       inserts, updates, and deletes on the table.
+
+    The below are the queries executed by this operation in order to avoid the
+    two problems above:
+
+    .. code-block:: sql
+
+      -- This operation takes an ACCESS EXCLUSIVE LOCK, but for a very short
+      -- duration. Adding a nullable field in Postgres doesn't require a full
+      -- table scan starting on version 11.
+      ALTER TABLE "foo" ADD COLUMN "bar_id" bigint NULL;
+
+      -- This operation takes an ShareUpdateExclusiveLock. It won't block
+      -- reads or writes on the table.
+      -- [Optional depending on db_index=True]
+      SET lock_timeout TO '0';
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_id_idx ON foo (bar_id);
+      SET lock_timeout TO '10s';
+
+      -- This operation will take a ShareRowExclusive lock on **both** the foo
+      -- table and the bar table. This will not block reads, but it
+      -- will block insert, updates, and deletes. This will only happen for a
+      -- short time, as this operation won't need to scan the whole table.
+      ALTER TABLE foo
+      ADD CONSTRAINT fk_post_bar FOREIGN KEY (bar_id)
+      REFERENCES bar (id)
+      DEFERRABLE INITIALLY DEFERRED
+      NOT VALID;
+
+      -- This query will take a ShareUpdateExclusive lock on the foo table does
+      -- not block reads nor writes), and a RowShare lock on the bar table
+      -- (does not block reads nor writes).
+      ALTER TABLE foo VALIDATE CONSTRAINT fk_post_bar;
+
+    **NOTE**: Additional queries that are triggered by this operation to
+    guarantee idempotency have been omitted from the snippet above. The key
+    take away is that if this migration fails, it can be attempted again and it
+    will pick up from where it has left (reentrancy).
+
+    **NOTE 2**: If you want to add a ``NOT NULL`` constraint after you have
+    backfilled the table, you can use the ``SaferAlterFieldSetNotNull``
+    operation.
+
+    How to use
+    ----------
+
+    1. Add a new ForeignKey field to your model
+
+    .. code-block:: diff
+
+      +    bar = models.ForeignKey(Bar, null=True, on_delete=models.CASCADE)
+
+    2. Make the new migration:
+
+    .. code-block:: bash
+
+      ./manage.py makemigrations
+
+    3. The only changes you need to perform are:
+
+       1. Swap Django's ``AddField`` for this package's
+          ``SaferAddFieldForeignKey`` operation.
+       2. Use a non-atomic migration.
+
+    .. code-block:: diff
+
+      + from django_pg_migration_tools import operations
+      from django.db import migrations
+
+
+      class Migration(migrations.Migration):
+      +   atomic = False
+
+          dependencies = [("myapp", "0042_dependency")]
+
+          operations = [
+      -        migrations.AddField(
+      +        operations.SaferAddFieldForeignKey(
+                  model_name="foo",
+                  name="bar",
+                  field=models.ForeignKey(
+                      null=True,
+                      on_delete=django.db.models.deletion.CASCADE,
+                      to='myapp.bar',
+                  ),
+              ),
+          ]

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -398,7 +398,7 @@ Class Definitions
           ]
 
 
-.. py:class:: SaferAlterFieldSetNotNull(model_name: str, name: str)
+.. py:class:: SaferAlterFieldSetNotNull(model_name: str, name: str, field: models.Field)
 
     Provides a safer way to alter a field to NOT NULL.
 

--- a/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
+++ b/tests/django_pg_migration_tools/management/commands/test_migrate_with_timeouts.py
@@ -142,11 +142,11 @@ class TestMigrateWithTimeoutsCommand:
             )
 
     def test_invalid_callback_path(self):
-        with pytest.raises(ModuleNotFoundError, match="No module named 'this.path'"):
+        with pytest.raises(ModuleNotFoundError, match="No module named 'some'"):
             management.call_command(
                 "migrate_with_timeouts",
                 lock_timeout_in_ms=50_000,
-                retry_callback_path="this.path.does.not.exist",
+                retry_callback_path="some.path.that.does.not.exist",
             )
 
     @pytest.mark.django_db(transaction=True)

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -1379,6 +1379,40 @@ class TestSaferRemoveUniqueConstraint:
         assert len(queries) == 1
 
 
+class TestIndexSQLBuilder:
+    def test_create_index(self):
+        idx_builder = operations.IndexSQLBuilder(
+            model_name="mymodel",
+            table_name="mytable",
+            column_name="mycolumn",
+        )
+        assert idx_builder.create_sql() == (
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            '"mymodel_mycolumn_idx" ON "mytable" ("mycolumn");'
+        )
+
+    def test_create_unique_index(self):
+        idx_builder = operations.IndexSQLBuilder(
+            model_name="mymodel",
+            table_name="mytable",
+            column_name="mycolumn",
+        )
+        assert idx_builder.create_sql(unique=True) == (
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            '"mymodel_mycolumn_idx" ON "mytable" ("mycolumn");'
+        )
+
+    def test_drop_index(self):
+        idx_builder = operations.IndexSQLBuilder(
+            model_name="mymodel",
+            table_name="mytable",
+            column_name="mycolumn",
+        )
+        assert idx_builder.remove_sql() == (
+            'DROP INDEX CONCURRENTLY IF EXISTS "mymodel_mycolumn_idx";'
+        )
+
+
 class TestSaferAlterFieldSetNotNull:
     app_label = "example_app"
 

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -17,6 +17,7 @@ from django.test import override_settings, utils
 from django_pg_migration_tools import operations
 from tests.example_app.models import (
     AnotherCharModel,
+    CharIDModel,
     CharModel,
     IntModel,
     NotNullIntFieldModel,
@@ -1754,4 +1755,702 @@ class TestSaferAlterFieldSetNotNull:
         assert queries[3]["sql"] == dedent("""
             ALTER TABLE "example_app_nullintfieldmodel"
             DROP CONSTRAINT "example_ap_int_field_59f69830a8";
+        """)
+
+
+class TestSaferSaferAddFieldForeignKey:
+    app_label = "example_app"
+
+    @pytest.mark.django_db
+    def test_requires_atomic_false(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+        with pytest.raises(NotSupportedError):
+            with connection.schema_editor(atomic=True) as editor:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+    @pytest.mark.django_db(transaction=True)
+    def test_when_not_null(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=False, on_delete=models.CASCADE),
+        )
+        with pytest.raises(
+            ValueError, match="Can't safely create a FK field with null=False"
+        ):
+            with connection.schema_editor(atomic=False) as editor:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+    @pytest.mark.django_db(transaction=True)
+    @override_settings(DATABASE_ROUTERS=[NeverAllow()])
+    def test_when_not_allowed_to_migrate_by_the_router(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        # No queries have run, because the migration wasn't allowed to run by
+        # the router.
+        assert len(queries) == 0
+
+        # Try the same for the reverse operation:
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        # No queries have run, because the migration wasn't allowed to run by
+        # the router.
+        assert len(queries) == 0
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation(self):
+        with connection.cursor() as cursor:
+            # Set the lock_timeout to check it has been returned to
+            # its original value once the fk index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        assert operation.describe() == (
+            "Add field char_model_field to intmodel. Note: Using "
+            "django_pg_migration_tools SaferAddFieldForeignKey operation."
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 9
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD COLUMN IF NOT EXISTS "char_model_field_id"
+            integer NULL;
+        """)
+        assert queries[2]["sql"] == "SHOW lock_timeout;"
+        assert queries[3]["sql"] == "SET lock_timeout = '0';"
+        assert queries[4]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert (
+            queries[5]["sql"]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "intmodel_char_model_field_id_idx" ON "example_app_intmodel" ("char_model_field_id");'
+        )
+        assert queries[6]["sql"] == "SET lock_timeout = '1s';"
+        assert queries[7]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk" FOREIGN KEY ("char_model_field_id")
+            REFERENCES "example_app_charmodel" ("id")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[8]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+        # Reversing again does nothing apart from checking the field doesn't
+        # exist anymore. This check the reverse migration is idempotent.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as second_reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(second_reverse_queries) == 1
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_column_already_exists(self):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD COLUMN IF NOT EXISTS "char_model_field_id"
+                integer NULL;
+            """)
+            # Also, set the lock_timeout to check it has been returned to
+            # its original value once the fk index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 9
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = true
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert queries[2]["sql"] == "SHOW lock_timeout;"
+        assert queries[3]["sql"] == "SET lock_timeout = '0';"
+        assert queries[4]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert (
+            queries[5]["sql"]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "intmodel_char_model_field_id_idx" ON "example_app_intmodel" ("char_model_field_id");'
+        )
+        assert queries[6]["sql"] == "SET lock_timeout = '1s';"
+        assert queries[7]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk" FOREIGN KEY ("char_model_field_id")
+            REFERENCES "example_app_charmodel" ("id")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[8]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_column_index_already_exists(self):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD COLUMN IF NOT EXISTS "char_model_field_id"
+                integer NULL;
+            """)
+            cursor.execute("""
+                CREATE INDEX "intmodel_char_model_field_id_idx"
+                ON "example_app_intmodel" ("char_model_field_id");
+            """)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 5
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = true
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert queries[2]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'example_app_intmodel_char_model_field_id_fk';
+        """)
+        assert queries[3]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk" FOREIGN KEY ("char_model_field_id")
+            REFERENCES "example_app_charmodel" ("id")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[4]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_invalid_constraint_already_exists(self):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD COLUMN IF NOT EXISTS "char_model_field_id"
+                integer NULL;
+            """)
+            cursor.execute("""
+                CREATE INDEX "intmodel_char_model_field_id_idx"
+                ON "example_app_intmodel" ("char_model_field_id");
+            """)
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk"
+                FOREIGN KEY ("char_model_field_id")
+                REFERENCES "example_app_charmodel" ("id")
+                DEFERRABLE INITIALLY DEFERRED
+                NOT VALID;
+            """)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 5
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = true
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert queries[2]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'example_app_intmodel_char_model_field_id_fk';
+        """)
+        assert queries[3]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_constraint
+            WHERE
+                conname = 'example_app_intmodel_char_model_field_id_fk'
+                AND convalidated IS TRUE;
+        """)
+        assert queries[4]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_valid_constraint_already_exists(self):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD COLUMN IF NOT EXISTS "char_model_field_id"
+                integer NULL;
+            """)
+            cursor.execute("""
+                CREATE INDEX "intmodel_char_model_field_id_idx"
+                ON "example_app_intmodel" ("char_model_field_id");
+            """)
+            cursor.execute("""
+                ALTER TABLE "example_app_intmodel"
+                ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk"
+                FOREIGN KEY ("char_model_field_id")
+                REFERENCES "example_app_charmodel" ("id")
+                DEFERRABLE INITIALLY DEFERRED;
+            """)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 4
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = true
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_model_field_id_idx'
+            );
+            """)
+        assert queries[2]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'example_app_intmodel_char_model_field_id_fk';
+        """)
+        assert queries[3]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_constraint
+            WHERE
+                conname = 'example_app_intmodel_char_model_field_id_fk'
+                AND convalidated IS TRUE;
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_db_index_is_false(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(
+                CharModel, db_index=False, null=True, on_delete=models.CASCADE
+            ),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 4
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD COLUMN IF NOT EXISTS "char_model_field_id"
+            integer NULL;
+        """)
+        assert queries[2]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk" FOREIGN KEY ("char_model_field_id")
+            REFERENCES "example_app_charmodel" ("id")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[3]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_model_field_id";
+        """)
+
+        # Reversing again does nothing apart from checking the field doesn't
+        # exist anymore. This check the reverse migration is idempotent.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as second_reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(second_reverse_queries) == 1
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_model_field_id';
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_related_model_does_not_use_int_id(self):
+        with connection.cursor() as cursor:
+            # Set the lock_timeout to check it has been returned to
+            # its original value once the fk index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_id_model_field",
+            field=models.ForeignKey(CharIDModel, null=True, on_delete=models.CASCADE),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(queries) == 9
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_id_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD COLUMN IF NOT EXISTS "char_id_model_field_id"
+            varchar(42) NULL;
+        """)
+        assert queries[2]["sql"] == "SHOW lock_timeout;"
+        assert queries[3]["sql"] == "SET lock_timeout = '0';"
+        assert queries[4]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_char_id_model_field_id_idx'
+            );
+            """)
+        assert (
+            queries[5]["sql"]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "intmodel_char_id_model_field_id_idx" ON "example_app_intmodel" ("char_id_model_field_id");'
+        )
+        assert queries[6]["sql"] == "SET lock_timeout = '1s';"
+        assert queries[7]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_char_id_model_field_id_fk" FOREIGN KEY ("char_id_model_field_id")
+            REFERENCES "example_app_charidmodel" ("id")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[8]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_char_id_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_id_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "char_id_model_field_id";
+        """)
+
+        # Reversing again does nothing apart from checking the field doesn't
+        # exist anymore. This check the reverse migration is idempotent.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as second_reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, project_state, new_state
+                )
+        assert len(second_reverse_queries) == 1
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'char_id_model_field_id';
         """)

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -1044,6 +1044,24 @@ class TestSaferAddUniqueConstraint:
             assert not cursor.fetchone()
 
 
+class TestBuildPostgresIdentifier:
+    def test_happy_path(self):
+        assert (
+            operations.build_postgres_identifier(
+                items=["item1", "item2"], suffix="suffix"
+            )
+            == "item1_item2_suffix"
+        )
+
+    def test_longer_than_63_char(self):
+        assert (
+            operations.build_postgres_identifier(
+                items=["a" * 32, "b" * 32], suffix="suffix"
+            )
+            == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_bbbbbbbbbbbbbb_bbeb3ff7_suffix"
+        )
+
+
 class TestSaferRemoveUniqueConstraint:
     app_label = "example_app"
 

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -36,3 +36,7 @@ class NullIntFieldModel(models.Model):
 class NotNullIntFieldModel(models.Model):
     # null=False is the default, but we set it here for clarity.
     int_field = models.IntegerField(null=False)
+
+
+class CharIDModel(models.Model):
+    id = models.CharField(max_length=42, primary_key=True)


### PR DESCRIPTION
# SaferAddFieldForeignKey

When adding a new foreign key field, Django uses an AddField operation
with a ForeignKey field. This operation triggers the following DDLs:

```sql
ALTER TABLE "foo" ADD COLUMN "bar_id" bigint NULL
REFERENCES "bar" ("id") DEFERRABLE INITIALLY DEFERRED;

-- optional: if the field doesn't set index=False
CREATE INDEX "foo_bar_idx" ON "foo" ("bar_id");
```

There are two problems:

1. The ALTER TABLE command takes an AccessExclusive lock, which is the
   highest level of locking. It will block reads and writes on both
   tables.
2. The CREATE INDEX takes a Share lock which will conflict with inserts,
   updates, and deletes on the table.

We want to achieve the same outcome as the above, but by performing DDLs
that block the database with locks that are as weak as possible, and for
the shortes time windows.

Say our foreign key model name is "bar". We trigger the following SQL:

```sql
-- This operation takes an ACCESS EXCLUSIVE LOCK, but for a very short
-- duration. Adding a nullable field in Postgres doesn't require a full
-- table scan starting on version 11.
ALTER TABLE "foo" ADD COLUMN "bar_id" bigint NULL;

-- This operation takes an ShareUpdateExclusiveLock. It won't block
-- reads or writes on the table.
-- [Optional depending on db_index=True]
SET lock_timeout TO '0';
CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_id_idx ON foo (bar_id);
SET lock_timeout TO '10s';

-- This operation will take a ShareRowExclusive lock on **both** the foo
-- table and the bar table. This will not block reads, but it
-- will block insert, updates, and deletes. This will only happen for a
-- short time, as this operation won't need to scan the whole table.
ALTER TABLE foo
ADD CONSTRAINT fk_post_bar FOREIGN KEY (bar_id)
REFERENCES bar (id)
DEFERRABLE INITIALLY DEFERRED
NOT VALID;

-- This query will take a ShareUpdateExclusive lock on the foo table (does
-- not block reads nor writes), and a RowShare lock on the bar
-- table (does not block reads nor writes).
ALTER TABLE foo VALIDATE CONSTRAINT fk_post_bar;
```