### PR TITLE
Bug fix safer fk operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug preventing the `SaferAddFieldForeignKey` operation of being
+  initialised with a `to` argument that is a string instead of models.Model
+
 ## [0.1.11] - 2024-12-06
 
 ### Added

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -2455,7 +2455,6 @@ class TestSaferSaferAddFieldForeignKey:
                 AND attname = 'char_id_model_field_id';
         """)
 
-    @pytest.mark.xfail
     @pytest.mark.django_db(transaction=True)
     def test_operation_when_referred_model_is_defined_as_str(self):
         project_state = ProjectState()


### PR DESCRIPTION
Running django-pg-migration-tools version v0.1.11 against an existing
codebase, revealed the following problem:

```sh
./manage.py sqlmigrate myapp 0042

File "/lib/python3.12/site-packages/django/db/migrations/migration.py", line 132, in apply
  operation.database_forwards(
File "/lib/python3.12/site-packages/django_pg_migration_tools/operations.py", line 1205, in database_forwards
  ForeignKeyManager(
File "/lib/python3.12/site-packages/django_pg_migration_tools/operations.py", line 1016, in __init__
  column_type: str | None = field.target_field.db_type(
                            ^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/db/models/fields/related.py", line 1059, in target_field
  return self.foreign_related_fields[0]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/utils/functional.py", line 57, in __get__
  res = instance.__dict__[self.name] = self.func(instance)
                                       ^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/db/models/fields/related.py", line 746, in foreign_related_fields
  rhs_field for lhs_field, rhs_field in self.related_fields if rhs_field
                                        ^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/utils/functional.py", line 57, in __get__
  res = instance.__dict__[self.name] = self.func(instance)
                                       ^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/db/models/fields/related.py", line 733, in related_fields
  return self.resolve_related_fields()
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/db/models/fields/related.py", line 1086, in resolve_related_fields
  related_fields = super().resolve_related_fields()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/lib/python3.12/site-packages/django/db/models/fields/related.py", line 711, in resolve_related_fields
  raise ValueError(

ValueError: Related model 'myapp.MyModel' cannot be resolved
```

This is a side-effect of the two ways in which a ForeignKey might be
initialised.

```py
    field=models.ForeignKey(
        CharModel,
        null=True,
        on_delete=models.CASCADE,
    )
```

or

```py
    field=models.ForeignKey(
        "example_app.CharModel",
        null=True,
        on_delete=models.CASCADE,
    )
```

This PR fixes the second, by inspecting Django state to grab the
model that matches the look-up str.