### PR TITLE
Use schema_editor for executing DDLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `schema_editor` instead of opening a new cursor for executing DDL
+  queries. This is so that `sqlmigrate` can show the queries without actually
+  running them.
+
 ## [0.1.12] - 2024-12-10
 
 ### Fixed


### PR DESCRIPTION
# Fix strange behaviour with `sqlmigrate`

Django's schema_editor.execute command is special because when running sqlmigrate it only collects the SQL statements without running them.

This is different from getting a cursor and running the query against the database, which would immediately run the DDL no matter what.

This commit fixes so that all the DDLs are run through the schema_editor.

This commit does not include the instropection queries because that will be a more difficult fix. That is because the schema_editor.execute function does not return a cursor where we can call .fetchone or .fetchall. So if we can't fetch the result, we can answer the question from the instropection query.

There are way to override this behaviour with a few hacks, but since it is not immediately pressing this will have to come on a subsequent work unit.