### PR TITLE
Bug fix introspection queries for sqlmigrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Introspection queries are now skipped when running `sqlmigrate`.
+
 ## [0.1.13] - 2024-12-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ### Fixed
 
-- Introspection queries are now skipped when running `sqlmigrate`.
+- Introspection queries are now skipped when running `sqlmigrate`. The result
+  of the `sqlmigrate` command will instead show a best-effort plan to perform
+  the migration without knowing the current state of the database. When running
+  `migrate`, however, the introspection queries will find the most adequate
+  plan; taking into consideration idempotency and reentrancy.
 
 ## [0.1.13] - 2024-12-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,3 +159,11 @@ filterwarnings = "error"
 # Ensure that tests fail if an xfail test unexpectedly passes.
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = "tests.example_app.settings"
+
+# Coverage
+# --------
+
+[tool.coverage.report]
+exclude_also = [
+    '@overload',
+]

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -142,7 +142,7 @@ class NullabilityQueries:
 
 
 @overload
-def _run_introspection_query(  # pragma: no cover
+def _run_introspection_query(
     schema_editor: base_schema.BaseDatabaseSchemaEditor,
     query: str,
     collect_default: bool = False,
@@ -150,7 +150,7 @@ def _run_introspection_query(  # pragma: no cover
 
 
 @overload
-def _run_introspection_query(  # pragma: no cover
+def _run_introspection_query(
     schema_editor: base_schema.BaseDatabaseSchemaEditor,
     query: str,
     collect_default: str,

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from textwrap import dedent
-from typing import Any, cast
+from typing import Any, cast, overload
 
 from django.contrib.postgres import operations as psql_operations
 from django.db import migrations, models
@@ -139,6 +139,44 @@ class NullabilityQueries:
         ALTER COLUMN {column_name}
         DROP NOT NULL;
     """)
+
+
+@overload
+def _run_introspection_query(  # pragma: no cover
+    schema_editor: base_schema.BaseDatabaseSchemaEditor,
+    query: str,
+    collect_default: bool = False,
+) -> bool: ...
+
+
+@overload
+def _run_introspection_query(  # pragma: no cover
+    schema_editor: base_schema.BaseDatabaseSchemaEditor,
+    query: str,
+    collect_default: str,
+) -> str: ...
+
+
+def _run_introspection_query(
+    schema_editor: base_schema.BaseDatabaseSchemaEditor,
+    query: str,
+    collect_default: bool | str = False,
+) -> bool | str:
+    if schema_editor.collect_sql:
+        # Running in `sqlmigrate` mode and just collecting queries.
+        # We don't display introspection queries in the output of `sqlmigrate`.
+        # To do so would be confusing, particularly because some introspective
+        # queries will only run in certain situations but not others. It
+        # depends on the state of the database schema.
+        return collect_default
+
+    # Running in `migrate` mode. Fetch the results for real.
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(query)
+    if isinstance(collect_default, bool):
+        return bool(cursor.fetchone())
+    else:
+        return str(cursor.fetchone()[0])
 
 
 def build_postgres_identifier(items: list[str], suffix: str) -> str:
@@ -281,15 +319,13 @@ class SafeIndexOperationManager(
         self,
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
     ) -> str:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(TimeoutQueries.SHOW_LOCK_TIMEOUT).as_string(
                 schema_editor.connection.connection
-            )
+            ),
+            collect_default="0",
         )
-        result = cursor.fetchone()[0]
-        assert isinstance(result, str)
-        return result
 
     def _ensure_not_an_invalid_index(
         self,
@@ -312,12 +348,13 @@ class SafeIndexOperationManager(
         be recreated on next steps via CREATE INDEX CONCURRENTLY IF EXISTS.
         """
         cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        result = _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(IndexQueries.CHECK_INVALID_INDEX)
             .format(index_name=psycopg_sql.Literal(index_name))
-            .as_string(schema_editor.connection.connection)
+            .as_string(schema_editor.connection.connection),
         )
-        if bool(cursor.fetchone()):
+        if result:
             cursor.execute(
                 psycopg_sql.SQL(IndexQueries.DROP_INDEX)
                 .format(index_name=psycopg_sql.Identifier(index_name))
@@ -497,13 +534,12 @@ class SafeConstraintOperationManager(base_operations.Operation):
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
         constraint: models.UniqueConstraint,
     ) -> bool:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(ConstraintQueries.CHECK_EXISTING_CONSTRAINT)
             .format(constraint_name=psycopg_sql.Literal(constraint.name))
-            .as_string(schema_editor.connection.connection)
+            .as_string(schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
 
 class SaferAddIndexConcurrently(psql_operations.AddIndexConcurrently):
@@ -859,16 +895,15 @@ class NullsManager(base_operations.Operation):
         table_name: str,
         column_name: str,
     ) -> bool:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(NullabilityQueries.IS_COLUMN_NOT_NULL)
             .format(
                 table_name=psycopg_sql.Literal(table_name),
                 column_name=psycopg_sql.Literal(column_name),
             )
-            .as_string(schema_editor.connection.connection)
+            .as_string(schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _get_constraint_name(self, table_name: str, column_name: str) -> str:
         """
@@ -888,13 +923,12 @@ class NullsManager(base_operations.Operation):
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
         constraint_name: str,
     ) -> bool:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(ConstraintQueries.CHECK_CONSTRAINT_IS_VALID)
             .format(constraint_name=psycopg_sql.Literal(constraint_name))
-            .as_string(schema_editor.connection.connection)
+            .as_string(schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _alter_table_not_null(
         self,
@@ -946,13 +980,12 @@ class NullsManager(base_operations.Operation):
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
         constraint_name: str,
     ) -> bool:
-        cursor = schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            schema_editor,
             psycopg_sql.SQL(ConstraintQueries.CHECK_EXISTING_CONSTRAINT)
             .format(constraint_name=psycopg_sql.Literal(constraint_name))
-            .as_string(schema_editor.connection.connection)
+            .as_string(schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _validate_constraint(
         self,
@@ -1121,16 +1154,15 @@ class ForeignKeyManager(base_operations.Operation):
         self._alter_table_drop_column()
 
     def _column_exists(self) -> bool:
-        cursor = self.schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            self.schema_editor,
             psycopg_sql.SQL(ColumnQueries.CHECK_COLUMN_EXISTS)
             .format(
                 table_name=psycopg_sql.Literal(self.table_name),
                 column_name=psycopg_sql.Literal(self.column_name),
             )
-            .as_string(self.schema_editor.connection.connection)
+            .as_string(self.schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _get_remote_model(self) -> models.Model:
         if isinstance(self.field.remote_field.model, str):
@@ -1168,13 +1200,12 @@ class ForeignKeyManager(base_operations.Operation):
         )
 
     def _valid_index_exists(self) -> bool:
-        cursor = self.schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            self.schema_editor,
             psycopg_sql.SQL(IndexQueries.CHECK_VALID_INDEX)
             .format(index_name=psycopg_sql.Literal(self.index_builder.name))
-            .as_string(self.schema_editor.connection.connection)
+            .as_string(self.schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _maybe_create_index(self) -> None:
         assert hasattr(self.field, "db_index")
@@ -1190,22 +1221,20 @@ class ForeignKeyManager(base_operations.Operation):
             )
 
     def _constraint_exists(self) -> bool:
-        cursor = self.schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            self.schema_editor,
             psycopg_sql.SQL(ConstraintQueries.CHECK_EXISTING_CONSTRAINT)
             .format(constraint_name=psycopg_sql.Literal(self.constraint_name))
-            .as_string(self.schema_editor.connection.connection)
+            .as_string(self.schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _is_constraint_valid(self) -> bool:
-        cursor = self.schema_editor.connection.cursor()
-        cursor.execute(
+        return _run_introspection_query(
+            self.schema_editor,
             psycopg_sql.SQL(ConstraintQueries.CHECK_CONSTRAINT_IS_VALID)
             .format(constraint_name=psycopg_sql.Literal(self.constraint_name))
-            .as_string(self.schema_editor.connection.connection)
+            .as_string(self.schema_editor.connection.connection),
         )
-        return bool(cursor.fetchone())
 
     def _alter_table_add_not_valid_fk(self) -> None:
         remote_model = self._get_remote_model()

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -254,6 +254,30 @@ class TestSaferAddIndexConcurrently:
             )
             assert not cursor.fetchone()
 
+    @pytest.mark.django_db(transaction=True)
+    def test_when_collecting_only(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+
+        index = Index(fields=["int_field"], name="int_field_idx")
+        operation = operations.SaferAddIndexConcurrently("IntModel", index)
+
+        with connection.schema_editor(atomic=False, collect_sql=True) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        assert len(queries) == 0
+
+        assert len(editor.collected_sql) == 3
+        editor.collected_sql[0] = "SET lock_timeout = '0';"
+        editor.collected_sql[1] = (
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS "int_field_idx" ON "example_app_intmodel" ("int_field");'
+        )
+        editor.collected_sql[2] = "SET lock_timeout = '0';"
+
     # Disable the overall test transaction because a concurrent index cannot
     # be triggered/tested inside of a transaction.
     @pytest.mark.django_db(transaction=True)
@@ -431,6 +455,31 @@ class TestSaferRemoveIndexConcurrently:
             == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "char_field_idx" ON "example_app_charmodel" ("char_field")'
         )
         assert reverse_queries[4]["sql"] == "SET lock_timeout = '1s';"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_when_collecting_only(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(CharModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferRemoveIndexConcurrently(
+            model_name="charmodel", name="char_field_idx"
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=True) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        assert len(queries) == 0
+
+        assert len(editor.collected_sql) == 3
+        editor.collected_sql[0] = "SET lock_timeout = '0';"
+        editor.collected_sql[1] = (
+            'DROP INDEX CONCURRENTLY IF EXISTS "int_field_idx" ON "example_app_intmodel" ("int_field");'
+        )
+        editor.collected_sql[2] = "SET lock_timeout = '0';"
 
     # Disable the overall test transaction because a concurrent index cannot
     # be triggered/tested inside of a transaction.
@@ -820,6 +869,39 @@ class TestSaferAddUniqueConstraint:
                 },
             )
             assert not cursor.fetchone()
+
+    @pytest.mark.django_db(transaction=True)
+    def test_when_collecting_only(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+
+        operation = operations.SaferAddUniqueConstraint(
+            model_name="intmodel",
+            constraint=UniqueConstraint(
+                fields=("int_field",),
+                name="unique_int_field",
+            ),
+        )
+        with connection.schema_editor(atomic=False, collect_sql=True) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        assert len(queries) == 0
+        assert len(editor.collected_sql) == 4
+
+        assert editor.collected_sql[0] == "SET lock_timeout = '0';"
+        assert (
+            editor.collected_sql[1]
+            == 'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "unique_int_field" ON "example_app_intmodel" ("int_field");'
+        )
+        assert editor.collected_sql[2] == "SET lock_timeout = '0';"
+        assert (
+            editor.collected_sql[3]
+            == 'ALTER TABLE "example_app_intmodel" ADD CONSTRAINT "unique_int_field" UNIQUE USING INDEX "unique_int_field";'
+        )
 
     # Disable the overall test transaction because a unique concurrent index
     # creation followed by a constraint addition cannot be triggered/tested
@@ -1577,6 +1659,46 @@ class TestSaferAlterFieldSetNotNull:
         """)
 
     @pytest.mark.django_db(transaction=True)
+    def test_when_collecting_only(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(NullIntFieldModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAlterFieldSetNotNull(
+            model_name="nullintfieldmodel",
+            name="int_field",
+            field=models.IntegerField(null=False),
+        )
+
+        with connection.schema_editor(atomic=False, collect_sql=True) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        assert len(queries) == 0
+
+        assert len(editor.collected_sql) == 4
+
+        assert editor.collected_sql[0] == dedent("""
+                ALTER TABLE "example_app_nullintfieldmodel"
+                ADD CONSTRAINT "example_ap_int_field_59f69830a8"
+                CHECK ("int_field" IS NOT NULL) NOT VALID;
+            """)
+        assert editor.collected_sql[1] == dedent("""
+                ALTER TABLE "example_app_nullintfieldmodel"
+                VALIDATE CONSTRAINT "example_ap_int_field_59f69830a8";
+            """)
+        assert editor.collected_sql[2] == dedent("""
+                ALTER TABLE "example_app_nullintfieldmodel"
+                ALTER COLUMN "int_field"
+                SET NOT NULL;
+            """)
+        assert editor.collected_sql[3] == dedent("""
+                ALTER TABLE "example_app_nullintfieldmodel"
+                DROP CONSTRAINT "example_ap_int_field_59f69830a8";
+            """)
+
+    @pytest.mark.django_db(transaction=True)
     def test_when_field_is_already_not_nullable(self):
         project_state = ProjectState()
         project_state.add_model(ModelState.from_model(NotNullIntFieldModel))
@@ -1946,6 +2068,48 @@ class TestSaferSaferAddFieldForeignKey:
             WHERE
                 attrelid = 'example_app_intmodel'::regclass
                 AND attname = 'char_model_field_id';
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_when_collecting_only(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="char_model_field",
+            field=models.ForeignKey(CharModel, null=True, on_delete=models.CASCADE),
+        )
+        with connection.schema_editor(atomic=False, collect_sql=True) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, project_state, new_state
+                )
+
+        assert len(queries) == 0
+        assert len(editor.collected_sql) == 6
+
+        assert editor.collected_sql[0] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD COLUMN IF NOT EXISTS "char_model_field_id"
+            integer NULL;
+                                        """)
+        assert editor.collected_sql[1] == "SET lock_timeout = '0';"
+        assert (
+            editor.collected_sql[2]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "intmodel_char_model_field_id_idx" ON "example_app_intmodel" ("char_model_field_id");'
+        )
+        assert editor.collected_sql[3] == "SET lock_timeout = '0';"
+        assert editor.collected_sql[4] == dedent("""
+           ALTER TABLE "example_app_intmodel"
+           ADD CONSTRAINT "example_app_intmodel_char_model_field_id_fk" FOREIGN KEY ("char_model_field_id")
+           REFERENCES "example_app_charmodel" ("id")
+           DEFERRABLE INITIALLY DEFERRED
+           NOT VALID;
+        """)
+        assert editor.collected_sql[5] == dedent("""
+           ALTER TABLE "example_app_intmodel"
+           VALIDATE CONSTRAINT "example_app_intmodel_char_model_field_id_fk";
         """)
 
     @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION

Many of the introspection queries here break when the `sqlmigrate`
command runs without an up-to-date database schema.

For example, take this introspection query for checking if the column
already exists:

```sql
  SELECT 1
  FROM pg_catalog.pg_attribute
  WHERE
      attrelid = {table_name}::regclass
      AND attname = {column_name};
```

If this introspection query run for real, in a database where the
{table_name} does not exist, it would return the following:

  django.db.utils.ProgrammingError: relation "table_name" does not exist
  LINE 5:     attrelid = 'table_name::regclass'

This happens because in certain cases the database doesn't have all
migrations applied and thus doesn't have a schema computed when the
sqlmigrate command runs.

This change adds a workaround, by not actually running the introspection
queries when sqlmigrate is running.

The introspection queries are also not printed to avoid confusion, as
they are not part of the plan per-se, and are more of a way for us to
make sure the operation is reentrant and idempotent.
