### PR TITLE
Add workflow to block fixup commits

### DIFF
--- a/.github/workflows/git.yaml
+++ b/.github/workflows/git.yaml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
A fixup is included to prove the workflow works (by failing)