### PR TITLE
Run migrate_with_timeouts with an advisory lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- The `migrate_with_timeouts` command now acquires a session-level advisory
+  lock before it begins. This helps preventing concurrent instances of the
+  migrate command from running at the same time, which could cause unexpected
+  crashes.
+
 ## [0.1.14] - 2024-12-17
 
 ### Added

--- a/tests/example_app/settings.py
+++ b/tests/example_app/settings.py
@@ -12,6 +12,10 @@ DATABASES = {
         default="postgres://postgres:postgres@localhost/django_pg_migration_tools",
     ),
 }
+# "secondary" is just an alias to serve multiple connections for tests
+# that need it.
+DATABASES["secondary"] = DATABASES["default"]
+
 SECRET_KEY = "test-secret-key"
 INSTALLED_APPS = [
     "tests.example_app",


### PR DESCRIPTION
Prior to this change, the migrate_with_timeouts command could run in
parallel multiple times.

This is a problem because many migration operations that are multi-step
and non-atomic will behave badly under such circumstances.

To prevent this of happening, this command will now require a
session-level advisory lock for the entirety of its procedure.

The session-level advisory lock will be automatically removed once the
management command finishes, whether successfully or not.

See:
  https://github.com/django/django/blob/857b1048/django/core/management/base.py#L426

Issue:
  https://github.com/kraken-tech/django-pg-migration-tools/issues/59

## Demo

The shell at the top ran the command with the following migration

<details>
Migration:

```py
# Generated by Django 5.1.4 on 2024-12-17 20:03

from django.db import migrations


def sleep(*args, **kwargs):
    import time
    time.sleep(777)


class Migration(migrations.Migration):

    dependencies = [
        ('blog', '0001_initial'),
    ]

    operations = [migrations.RunPython(sleep)]

```
</details>

The shell at the top try to run the migration command again, and failed
immediatelly

<img width="821" alt="image" src="https://github.com/user-attachments/assets/13a0cfd8-4fa4-43dc-9158-ed39485738f4" />
