### PR TITLE
Add unique index class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- A new type of index `UniqueIndex` that also accepts conditions.
+
 ## [0.1.15] - 2024-12-19
 
 ### Changed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Install from pypi::
    :maxdepth: 3
    :caption: Contents
 
-   usage/timeouts
-   usage/operations
+   usage/indexes
    usage/management_commands
+   usage/operations
+   usage/timeouts

--- a/docs/usage/indexes.rst
+++ b/docs/usage/indexes.rst
@@ -1,0 +1,91 @@
+Indexes
+=======
+
+``UniqueIndex``
+---------------
+
+Creates a ``UNIQUE`` postgres index.
+
+Django doesn't have an operation to create a unique index.
+
+The next best thing Django provides is a ``UniqueConstraint``.
+However, unique constraints in Postgres can't be partial (i.e., have
+conditions) so there is a gap in functionality that is covered by this special
+index class.
+
+++++++++++
+How to use
+++++++++++
+
+The interface is the same as Django's models.Index class:
+
+.. code-block:: diff
+
+    from django.db import models
+  + from django_pg_migration_tools import indexes
+
+    class CharModel(models.Model):
+        char_field = models.CharField(max_length=42)
+
+        class Meta:
+            indexes = [
+                ...,
+  +             indexes.UniqueIndex(
+  +                 name="unique_char_unless_foo",
+  +                 fields=["char_field"],
+  +                 condition=~models.Q(char_field="foo")
+  +             )
+            ]
+
+
+    class IntModel(models.Model):
+        int_field = models.IntegerField()
+
+        class Meta:
+            indexes = [
+                ...,
+  +             indexes.UniqueIndex(
+  +                 name="unique_int",
+  +                 fields=["int_field"],
+  +             )
+            ]
+
+
+Note: If you are creating a new unique index in a table that already exists,
+you can use the :ref:`SaferAddIndexConcurrently <safer_add_index_concurrently>`
+operation.
+
+.. code-block:: diff
+
+    import django_pg_migration_tools.indexes
+    from django.db import migrations, models
+
+  + from django_pg_migration_tools import operations
+
+
+    class Migration(migrations.Migration):
+  +     atomic = False
+
+        dependencies = [
+            ('myapp', '0001_initial'),
+        ]
+
+        operations = [
+  -         migrations.AddIndex(
+  +         operations.SaferAddIndexConcurrently(
+                model_name='charmodel',
+                index=django_pg_migration_tools.indexes.UniqueIndex(
+                    condition=models.Q(('char_field', 'foo'), _negated=True),
+                    fields=['char_field'],
+                    name='unique_char_unless_foo',
+                ),
+            ),
+  -         migrations.AddIndex(
+  +         operations.SaferAddIndexConcurrently(
+                model_name='intmodel',
+                index=django_pg_migration_tools.indexes.UniqueIndex(
+                    fields=['int_field'],
+                    name='unique_int',
+                ),
+            ),
+        ]

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -6,6 +6,7 @@ Provides custom migration operations that help developers perform idempotent and
 Class Definitions
 -----------------
 
+.. _safer_add_index_concurrently:
 .. py:class:: SaferAddIndexConcurrently(model_name: str, index: models.Index)
 
     Performs CREATE INDEX CONCURRENTLY IF NOT EXISTS without a lock_timeout

--- a/src/django_pg_migration_tools/indexes.py
+++ b/src/django_pg_migration_tools/indexes.py
@@ -1,0 +1,19 @@
+from django.db import models
+from django.db.backends import ddl_references
+from django.db.backends.base import schema as base_schema
+from django.db.models.indexes import Index
+
+
+class UniqueIndex(Index):
+    def create_sql(
+        self,
+        model: type[models.Model],
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        using: str = "",
+        **kwargs: object,
+    ) -> ddl_references.Statement:
+        statement = super().create_sql(model, schema_editor, using, **kwargs)
+        statement.template = statement.template.replace(
+            "CREATE INDEX", "CREATE UNIQUE INDEX"
+        )
+        return statement

--- a/tests/django_pg_migration_tools/test_indexes.py
+++ b/tests/django_pg_migration_tools/test_indexes.py
@@ -1,0 +1,72 @@
+import pytest
+from django.db import connection, models
+
+from django_pg_migration_tools import indexes
+from tests.example_app.models import CharModel
+
+
+class TestUniqueIndex:
+    app_label = "example_app"
+
+    @pytest.mark.django_db
+    def test_non_partial_index(self):
+        with connection.schema_editor() as editor:
+            index = indexes.UniqueIndex(
+                name="recent_dt_idx",
+                fields=["char_field"],
+            )
+            assert (
+                'CREATE UNIQUE INDEX "recent_dt_idx" '
+                'ON "example_app_charmodel" ("char_field")'
+            ) == str(index.create_sql(CharModel, schema_editor=editor))
+
+            editor.add_index(index=index, model=CharModel)
+            with connection.cursor() as cursor:
+                assert index.name in connection.introspection.get_constraints(
+                    cursor=cursor,
+                    table_name=CharModel._meta.db_table,
+                )
+            editor.remove_index(index=index, model=CharModel)
+
+    @pytest.mark.django_db
+    def test_partial_index(self):
+        with connection.schema_editor() as editor:
+            index = indexes.UniqueIndex(
+                name="partial_char_field_idx",
+                fields=["char_field"],
+                condition=~models.Q(char_field="foo"),
+            )
+            assert (
+                'CREATE UNIQUE INDEX "partial_char_field_idx" '
+                'ON "example_app_charmodel" ("char_field") WHERE NOT ('
+                "\"char_field\" = 'foo')"
+            ) == str(index.create_sql(CharModel, schema_editor=editor))
+
+            editor.add_index(index=index, model=CharModel)
+            with connection.cursor() as cursor:
+                assert index.name in connection.introspection.get_constraints(
+                    cursor=cursor,
+                    table_name=CharModel._meta.db_table,
+                )
+            editor.remove_index(index=index, model=CharModel)
+
+    @pytest.mark.django_db
+    def test_partial_int_index(self):
+        with connection.schema_editor() as editor:
+            index = indexes.UniqueIndex(
+                name="partial_pk_idx",
+                fields=["id"],
+                condition=models.Q(pk__gt=1),
+            )
+            assert (
+                'CREATE UNIQUE INDEX "partial_pk_idx" ON "example_app_charmodel" '
+                '("id") WHERE "id" > 1'
+            ) == str(index.create_sql(CharModel, schema_editor=editor))
+
+            editor.add_index(index=index, model=CharModel)
+            with connection.cursor() as cursor:
+                assert index.name in connection.introspection.get_constraints(
+                    cursor=cursor,
+                    table_name=CharModel._meta.db_table,
+                )
+            editor.remove_index(index=index, model=CharModel)


### PR DESCRIPTION
Django only supports unique constraints at the moment. There is no
support for unique indexes, specially partial unique indexes.

This PR adds a class that can be used in the Meta::indexes array.

## Local Tests

Using the following models

```py
class IntModel(models.Model):
    int_field = models.IntegerField()

    class Meta:
        indexes = [
            indexes.UniqueIndex(
                name="unique_int",
                fields=["int_field"],
            )
        ]


class CharModel(models.Model):
    char_field = models.CharField(max_length=42)

    class Meta:
        indexes = [
            indexes.UniqueIndex(
                name="unique_char_unless_foo",
                fields=["char_field"],
                condition=~models.Q(char_field="foo")
            )
        ]

```

Which creates the following default migration:

```
CREATE UNIQUE INDEX "unique_char_unless_foo" ON "blog_charmodel" ("char_field") WHERE NOT ("char_field" = 'foo');
CREATE UNIQUE INDEX "unique_int" ON "blog_intmodel" ("int_field");
```

It also works with the safer index operation:

```
(env) [sandbox] ./manage.py sqlmigrate blog 0003
--
-- Concurrently creates index unique_char_unless_foo on field(s) ['char_field'] of model charmodel if the index does not exist. NOTE: Using django_pg_migration_tools SaferAddIndexConcurrently operation.
--
SET lock_timeout = '0';
CREATE UNIQUE INDEX CONCURRENTLY "unique_char_unless_foo" ON "blog_charmodel" ("char_field") WHERE NOT ("char_field" = 'foo');
SET lock_timeout = '0';
--
-- Concurrently creates index unique_int on field(s) ['int_field'] of model intmodel if the index does not exist. NOTE: Using django_pg_migration_tools SaferAddIndexConcurrently operation.
--
SET lock_timeout = '0';
CREATE UNIQUE INDEX CONCURRENTLY "unique_int" ON "blog_intmodel" ("int_field");
SET lock_timeout = '0';
```

```
sandbox=# \d+ blog_charmodel
                                                           Table "public.blog_charmodel"
   Column   |         Type          | Collation | Nullable |             Default              | Storage  | Compression | Stats target | Description
------------+-----------------------+-----------+----------+----------------------------------+----------+-------------+--------------+-------------
 id         | bigint                |           | not null | generated by default as identity | plain    |             |              |
 char_field | character varying(42) |           | not null |                                  | extended |             |              |
Indexes:
    "blog_charmodel_pkey" PRIMARY KEY, btree (id)
    "unique_char_unless_foo" UNIQUE, btree (char_field) WHERE NOT char_field::text = 'foo'::text
Access method: heap

sandbox=# \d+ blog_intmodel
                                                    Table "public.blog_intmodel"
  Column   |  Type   | Collation | Nullable |             Default              | Storage | Compression | Stats target | Description
-----------+---------+-----------+----------+----------------------------------+---------+-------------+--------------+-------------
 id        | bigint  |           | not null | generated by default as identity | plain   |             |              |
 int_field | integer |           | not null |                                  | plain   |             |              |
Indexes:
    "blog_intmodel_pkey" PRIMARY KEY, btree (id)
    "unique_int" UNIQUE, btree (int_field)
Access method: heap
```