### PR TITLE
Safer Add Field OneToOne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 ### Added
 
 - A new type of index `UniqueIndex` that also accepts conditions.
+- A new operation to add one-to-one fields in a safer way:
+  `SaferAddFieldOneToOne`.
 
 ## [0.1.15] - 2024-12-19
 

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -510,7 +510,7 @@ Class Definitions
 
     :param model_name: Model name in lowercase without underscores.
     :type model_name: str
-    :param name: The column name to be set as not null.
+    :param name: The column name for the new foreign key.
     :type name: str
     :param field: The foreign key field that is being added.
     :type field: models.ForeignKey
@@ -564,9 +564,9 @@ Class Definitions
       DEFERRABLE INITIALLY DEFERRED
       NOT VALID;
 
-      -- This query will take a ShareUpdateExclusive lock on the foo table does
-      -- not block reads nor writes), and a RowShare lock on the bar table
-      -- (does not block reads nor writes).
+      -- This query will take a ShareUpdateExclusive lock on the foo table
+      -- (does not block reads nor writes), and a RowShare lock on the bar
+      -- table (does not block reads nor writes).
       ALTER TABLE foo VALIDATE CONSTRAINT fk_post_bar;
 
     **NOTE**: Additional queries that are triggered by this operation to


### PR DESCRIPTION
The default SQL DDL statements produced by Django to create a
OneToOneField are not safe to run and can cause outages.

For example, when the following foo field is added to Bar:
```py
  class Bar(models.Model):
      foo = models.OneToOneField(
          Foo,
          on_delete=models.CASCADE,
          primary_key=False,  # False is the default
          null=True,
      )
```
A new migration is created via makemigrations with the following
operation:
```py
  operations = [
      migrations.AddField(
          model_name='bar',
          name='foo',
          field=models.OneToOneField(
              null=True,
              on_delete=django.db.models.deletion.CASCADE,
              to='blog.foo'
          ),
      ),
  ]
```
This operation, in turn, produces the following statements:
```sql
  BEGIN;
  --
  -- Add field foo to bar
  --
  ALTER TABLE "blog_bar"
  ADD COLUMN "foo_id" bigint NULL
  UNIQUE CONSTRAINT "auto_gen_constraint_name"
  REFERENCES "blog_foo"("id")
  DEFERRABLE INITIALLY DEFERRED;

  SET CONSTRAINTS "auto_gen_constraint_name" IMMEDIATE;
  COMMIT;
```
This is not safe, the ALTER TABLE requires an AccessExclusiveLock on
the bar table, and a ShareRowExclusiveLock on the foo table. Same for
the SET CONSTRAINTS command.

The new SaferAddFieldOneToOne provides an alternative, by creating both
the unique constraint and the fk constraint using the safer operations
that are already included in this library.