### PR TITLE
Add a Main Features section in the README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,14 +167,15 @@ To publish a new version of this package:
 1. Update the version in pyproject.toml.
 2. Check all changes have been recorded in the changelog.
 3. Add a heading in the changelog for the new version, including today's date.
-4. Commit the changes and open a PR.
-5. Once the PR is approved, rebase the branch to get the latest changes and tag
+4. Check if the README.md "Main Features" section needs updating.
+5. Commit the changes and open a PR.
+6. Once the PR is approved, rebase the branch to get the latest changes and tag
    the merge commit with the new version:
    ```sh
    git tag 'v0.0.0'
    git push origin --tags
    ```
-6. The build_and_publish workflow will verify that the tag, package version,
+7. The build_and_publish workflow will verify that the tag, package version,
    and changelog all contain the same version number and publish the package
    to PyPI.
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ Tools to make Django migrations safer and more scalable.
 ## Documentation
 
 [Full documentation](https://django-pg-migration-tools.readthedocs.io/en/latest/).
+
+## Main Features
+
+- **Safer migration operations for**:
+  - [Adding unique constraints](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferAddUniqueConstraint)
+  - [Removing unique constraints](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferRemoveUniqueConstraint)
+  - [Adding check constraints](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferAddCheckConstraint)
+  - [Adding indexes (concurrently)](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferAddIndexConcurrently)
+  - [Removing indexes (concurrently)](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferRemoveIndexConcurrently)
+  - [Setting a column to NOT NULL](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferAlterFieldSetNotNull)
+  - [Adding foreign keys](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/operations.html#SaferAddFieldForeignKey)
+
+- **Database timeouts**:
+  - A context manager to apply `statement_timeout` and/or `lock_timeout` to
+    either a transaction or a Postgres session. See [apply_timeouts](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/timeouts.html#timeouts.apply_timeouts)
+
+- **Management commands**:
+  - Run migrations with `statement_timeout` and `lock_timeout` by using
+    [migrate_with_timeouts](https://django-pg-migration-tools.readthedocs.io/en/latest/usage/management_commands.html#migrate-with-timeouts)


### PR DESCRIPTION
Prior to this change, the README.md file was looking rather empty. The only important information it contained was a link to the full documentation (ReadTheDocs page).

In some cases, potential users might come to the GitHub repository page directly and face a blank wall.

This commit adds a summary of the main features to the README.md with some click links for interested parties to navigate them.

## Preview the changes

https://github.com/kraken-tech/django-pg-migration-tools/tree/add-readme-main-features-section