### PR TITLE
Safer remove field foreign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 - Enhanced `SaferAddUniqueConstraint` to support a `UniqueConstraint` with the
   `deferrable` argument.
+- A new operation to remove a foreign key field: `SaferRemoveFieldForeignKey`.
 
 ## [0.1.16] - 2025-01-08
 

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -1262,12 +1262,12 @@ class ForeignKeyManager(base_operations.Operation):
         ):
             return
 
-        if not self._column_exists():
+        if not self._column_exists(collect_default=True):
             return
 
         self._alter_table_drop_column()
 
-    def _column_exists(self) -> bool:
+    def _column_exists(self, collect_default: bool = False) -> bool:
         return _run_introspection_query(
             self.schema_editor,
             psycopg_sql.SQL(ColumnQueries.CHECK_COLUMN_EXISTS)
@@ -1276,6 +1276,7 @@ class ForeignKeyManager(base_operations.Operation):
                 column_name=psycopg_sql.Literal(self.column_name),
             )
             .as_string(self.schema_editor.connection.connection),
+            collect_default=collect_default,
         )
 
     def _get_remote_model(self) -> models.Model:

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -1456,6 +1456,59 @@ class SaferAddFieldForeignKey(operation_fields.AddField):
         )
 
 
+class SaferRemoveFieldForeignKey(operation_fields.RemoveField):
+    def database_forwards(
+        self,
+        app_label: str,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        from_state: migrations.state.ProjectState,
+        to_state: migrations.state.ProjectState,
+    ) -> None:
+        field = from_state.apps.get_model(app_label, self.model_name)._meta.get_field(
+            self.name
+        )
+        ForeignKeyManager(
+            app_label,
+            schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+            model=to_state.apps.get_model(app_label, self.model_name),
+            model_name=self.model_name,
+            column_name=self.name,
+            field=field,
+            unique=False,
+        ).drop_fk_field()
+
+    def database_backwards(
+        self,
+        app_label: str,
+        schema_editor: base_schema.BaseDatabaseSchemaEditor,
+        from_state: migrations.state.ProjectState,
+        to_state: migrations.state.ProjectState,
+    ) -> None:
+        field = to_state.apps.get_model(app_label, self.model_name)._meta.get_field(
+            self.name
+        )
+        ForeignKeyManager(
+            app_label,
+            schema_editor,
+            from_state=from_state,
+            to_state=to_state,
+            model=to_state.apps.get_model(app_label, self.model_name),
+            model_name=self.model_name,
+            column_name=self.name,
+            field=field,
+            unique=False,
+        ).add_fk_field()
+
+    def describe(self) -> str:
+        base = super().describe()
+        return (
+            f"{base}. Note: Using django_pg_migration_tools "
+            f"SaferRemoveFieldForeignKey operation."
+        )
+
+
 class SaferAddFieldOneToOne(operation_fields.AddField):
     """
     Django's OneToOneField behaves the same way as a ForeignKey. Except that

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -2024,7 +2024,7 @@ class TestSaferAlterFieldSetNotNull:
         """)
 
 
-class TestSaferSaferAddFieldForeignKey:
+class TestSaferAddFieldForeignKey:
     app_label = "example_app"
 
     @pytest.mark.django_db

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -2194,7 +2194,7 @@ class TestSaferAddFieldForeignKey:
                 )
         assert len(second_reverse_queries) == 1
 
-        assert reverse_queries[0]["sql"] == dedent("""
+        assert second_reverse_queries[0]["sql"] == dedent("""
             SELECT 1
             FROM pg_catalog.pg_attribute
             WHERE

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -988,7 +988,7 @@ class TestSaferAddUniqueConstraint:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
 
         with connection.cursor() as cursor:
@@ -1043,7 +1043,7 @@ class TestSaferAddUniqueConstraint:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as reverse_queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
 
         # 1. Check that the constraint is still there.
@@ -2041,7 +2041,7 @@ class TestSaferRemoveFieldForeignKey:
         with pytest.raises(NotSupportedError):
             with connection.schema_editor(atomic=True) as editor:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
 
     @pytest.mark.django_db(transaction=True)
@@ -2060,7 +2060,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
         # No queries have run, because the migration wasn't allowed to run by
         # the router.
@@ -2070,7 +2070,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
 
         # No queries have run, because the migration wasn't allowed to run by
@@ -2103,7 +2103,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
 
         assert len(queries) == 2
@@ -2123,7 +2123,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as reverse_queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
 
         assert len(reverse_queries) == 9
@@ -2174,7 +2174,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as second_reverse_queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
         assert len(second_reverse_queries) == 4
         assert second_reverse_queries[0]["sql"] == dedent("""
@@ -2227,7 +2227,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
 
         assert len(queries) == 1
@@ -2243,7 +2243,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=False) as editor:
             with utils.CaptureQueriesContext(connection) as reverse_queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
 
         assert len(reverse_queries) == 9
@@ -2308,7 +2308,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=True) as editor:
             with utils.CaptureQueriesContext(connection) as queries:
                 operation.database_forwards(
-                    self.app_label, editor, project_state, new_state
+                    self.app_label, editor, from_state=project_state, to_state=new_state
                 )
 
         assert len(queries) == 0
@@ -2322,7 +2322,7 @@ class TestSaferRemoveFieldForeignKey:
         with connection.schema_editor(atomic=False, collect_sql=True) as editor:
             with utils.CaptureQueriesContext(connection) as reverse_queries:
                 operation.database_backwards(
-                    self.app_label, editor, new_state, project_state
+                    self.app_label, editor, from_state=new_state, to_state=project_state
                 )
 
         assert len(reverse_queries) == 0

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -5,6 +5,10 @@ class IntModel(models.Model):
     int_field = models.IntegerField(default=0)
 
 
+class ModelWithForeignKey(models.Model):
+    fk = models.ForeignKey(IntModel, null=True, on_delete=models.CASCADE)
+
+
 class CharModel(models.Model):
     char_field = models.CharField(default="char")
 


### PR DESCRIPTION
This is the analogous of `SaferAddFieldForeignKey` but does the opposite (-: