### PR TITLE
Add deferrable to safer unique constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Enhanced `SaferAddUniqueConstraint` to support a `UniqueConstraint` with the
+  `deferrable` argument.
+
 ## [0.1.16] - 2025-01-08
 
 ### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,10 @@ author = "Kraken Tech"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx_rtd_theme"]
+extensions = [
+    "sphinx_rtd_theme",
+    "sphinx_design",
+]
 html_theme = "sphinx_rtd_theme"
 
 html_context = {

--- a/docs/usage/operations.rst
+++ b/docs/usage/operations.rst
@@ -285,6 +285,19 @@ Class Definitions
       -- Perform the ALTER TABLE using the unique index just created.
       ALTER TABLE "myapp_mymodel" ADD CONSTRAINT "foo_unique" UNIQUE USING INDEX "foo_unique_idx";
 
+    .. dropdown:: Information about ``deferrable``
+        :color: info
+        :icon: info
+
+        The ``deferrable`` argument of ``UniqueConstraint`` is respected.
+
+        That is, if set to ``models.Deferrable.DEFERRED``, the ``ALTER TABLE``
+        command above will include the suffix ``DEFERRABLE INITIALLY
+        DEFERRED``.
+
+        The other value for ``models.Deferrable`` is ``IMMEDIATE``. No changes
+        are performed on the ``ALTER TABLE`` statement in this case as
+        ``IMMEDIATE`` is the default Postgres behaviour.
 
     How to use
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ docs = [
   "sphinx>=7.4.7",
   "sphinx_rtd_theme>=2.0.0",
   "sphinx_lint>=0.9.1",
+  "sphinx_design>=0.6.1",
 ]
 dev = [
     # Testing

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -40,7 +40,7 @@ docutils==0.21.2
     # via
     #   sphinx
     #   sphinx-rtd-theme
-environs==14.0.0
+environs==14.1.0
     # via django-pg-migration-tools (pyproject.toml)
 filelock==3.16.1
     # via virtualenv
@@ -56,7 +56,7 @@ jinja2==3.1.5
     # via sphinx
 markupsafe==3.0.2
     # via jinja2
-marshmallow==3.24.1
+marshmallow==3.25.1
     # via environs
 mypy==1.14.1
     # via django-pg-migration-tools (pyproject.toml)
@@ -103,7 +103,7 @@ regex==2024.11.6
     # via sphinx-lint
 requests==2.32.3
     # via sphinx
-ruff==0.8.6
+ruff==0.9.1
     # via django-pg-migration-tools (pyproject.toml)
 snowballstemmer==2.2.0
     # via sphinx

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -110,8 +110,11 @@ snowballstemmer==2.2.0
 sphinx==8.1.3
     # via
     #   django-pg-migration-tools (pyproject.toml)
+    #   sphinx-design
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
+sphinx-design==0.6.1
+    # via django-pg-migration-tools (pyproject.toml)
 sphinx-lint==1.0.0
     # via django-pg-migration-tools (pyproject.toml)
 sphinx-rtd-theme==3.0.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -35,8 +35,11 @@ snowballstemmer==2.2.0
 sphinx==8.1.3
     # via
     #   django-pg-migration-tools (pyproject.toml)
+    #   sphinx-design
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
+sphinx-design==0.6.1
+    # via django-pg-migration-tools (pyproject.toml)
 sphinx-lint==1.0.0
     # via django-pg-migration-tools (pyproject.toml)
 sphinx-rtd-theme==3.0.2

--- a/requirements/pytest-in-nox-psycopg2.txt
+++ b/requirements/pytest-in-nox-psycopg2.txt
@@ -23,13 +23,13 @@ django-stubs==5.1.1
     # via django-pg-migration-tools (pyproject.toml)
 django-stubs-ext==5.1.1
     # via django-stubs
-environs==14.0.0
+environs==14.1.0
     # via django-pg-migration-tools (pyproject.toml)
 filelock==3.16.1
     # via virtualenv
 iniconfig==2.0.0
     # via pytest
-marshmallow==3.24.1
+marshmallow==3.25.1
     # via environs
 nox==2024.10.9
     # via django-pg-migration-tools (pyproject.toml)

--- a/requirements/pytest-in-nox-psycopg3.txt
+++ b/requirements/pytest-in-nox-psycopg3.txt
@@ -23,13 +23,13 @@ django-stubs==5.1.1
     # via django-pg-migration-tools (pyproject.toml)
 django-stubs-ext==5.1.1
     # via django-stubs
-environs==14.0.0
+environs==14.1.0
     # via django-pg-migration-tools (pyproject.toml)
 filelock==3.16.1
     # via virtualenv
 iniconfig==2.0.0
     # via pytest
-marshmallow==3.24.1
+marshmallow==3.25.1
     # via environs
 nox==2024.10.9
     # via django-pg-migration-tools (pyproject.toml)

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -455,6 +455,19 @@ class SafeConstraintOperationManager(base_operations.Operation):
         alter_table_sql = base_sql.split(" UNIQUE")[0]
         sql = f'{alter_table_sql} UNIQUE USING INDEX "{index.name}"'
 
+        if constraint.deferrable == models.Deferrable.DEFERRED:
+            sql += " DEFERRABLE INITIALLY DEFERRED"
+        else:
+            # Note that there are only two options for models.Deferrable:
+            # IMMEDIATE or DEFERRED. models.Deferrable.IMMEDIATE is the default
+            # and most common case. DEFERRED is also Postgres default when no
+            # deferrable setting was specified. This means that having an
+            # "else" here that would append "DEFERRABLE INITIALLY IMMEDIATE"
+            # to the query for the "IMMEDIATE" case is not necessary. This
+            # mimics what Django already does, which is to not include that
+            # suffix.
+            pass
+
         # Now we can execute the schema change. We have lock timeouts back in
         # place after creating the index that would prevent this operation from
         # running for too long if it's blocked by another query. Otherwise,


### PR DESCRIPTION
## Description

Add support for `UniqueConstraint.deferrable`.

Here is a bare Django UniqueConstraint:

```py
class Foo(models.Model):
    int_field = models.IntegerField(null=True)

    class Meta:
        constraints = [
            UniqueConstraint(fields=['int_field'], name='unique_int_field'),
        ]
```

That generates the following SQL:

```sql
ALTER TABLE "blog_foo" ADD CONSTRAINT "unique_int_field" UNIQUE ("int_field");
```

So far so good. But Django allows a `deferrable` argument.
Accepted values are Deferrable.DEFERRED or Deferrable.IMMEDIATE. For example:

```py
from django.db.models import Deferrable, UniqueConstraint

UniqueConstraint(
    fields=['int_field'],
    name='unique_int_field',
    deferrable=Deferrable.DEFERRED,
)
```

If Deferrable.DEFERRED, the migration output is:

```sql
ALTER TABLE "blog_foo" ADD CONSTRAINT "unique_int_field" UNIQUE ("int_field") DEFERRABLE INITIALLY DEFERRED;
```

If Deferrable.IMMEDIATE, the migration output is:

```sql
ALTER TABLE "blog_foo" DROP CONSTRAINT "unique_int_field";
```

The DEFERRABLE INITIALLY IMMEDIATE setup is the default, so Django doesn't have
to alter the DDL statement.
