### PR TITLE
Fix safer alter field set not null for fk fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `SaferAlterFieldSetNotNull` did not work when the field dropping the NOT NULL
+  constraint was a ForeignKey. An error such as:
+  `django.db.utils.ProgrammingError: column "foo" does not exist` would have
+  been raised instead.
+
 ## [0.1.17] - 2025-01-14
 
 ### Added

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -1111,11 +1111,12 @@ class SaferAlterFieldSetNotNull(operation_fields.AlterField):
         from_state: migrations.state.ProjectState,
         to_state: migrations.state.ProjectState,
     ) -> None:
+        model = to_state.apps.get_model(app_label, self.model_name)
         NullsManager().set_not_null(
             app_label,
             schema_editor,
-            model=to_state.apps.get_model(app_label, self.model_name),
-            column_name=self.name,
+            model=model,
+            column_name=model._meta.get_field(self.name).column,
         )
 
     def database_backwards(
@@ -1125,11 +1126,12 @@ class SaferAlterFieldSetNotNull(operation_fields.AlterField):
         from_state: migrations.state.ProjectState,
         to_state: migrations.state.ProjectState,
     ) -> None:
+        model = to_state.apps.get_model(app_label, self.model_name)
         NullsManager().set_null(
             app_label,
             schema_editor,
-            model=to_state.apps.get_model(app_label, self.model_name),
-            column_name=self.name,
+            model=model,
+            column_name=model._meta.get_field(self.name).column,
         )
 
     def describe(self) -> str:

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -1693,7 +1693,6 @@ class TestSaferAlterFieldSetNotNull:
         # the router.
         assert len(queries) == 0
 
-    @pytest.mark.xfail
     @pytest.mark.django_db(transaction=True)
     def test_when_field_is_a_foreign_key(self):
         project_state = ProjectState()

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -23,6 +23,7 @@ from tests.example_app.models import (
     ModelWithCheckConstraint,
     ModelWithForeignKey,
     NotNullIntFieldModel,
+    NullFKFieldModel,
     NullIntFieldModel,
     get_check_constraint,
 )
@@ -1691,6 +1692,100 @@ class TestSaferAlterFieldSetNotNull:
         # No queries have run, because the migration wasn't allowed to run by
         # the router.
         assert len(queries) == 0
+
+    @pytest.mark.xfail
+    @pytest.mark.django_db(transaction=True)
+    def test_when_field_is_a_foreign_key(self):
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        project_state.add_model(ModelState.from_model(NullFKFieldModel))
+        new_state = project_state.clone()
+        operation = operations.SaferAlterFieldSetNotNull(
+            model_name="nullfkfieldmodel",
+            name="fk",
+            field=models.ForeignKey(
+                on_delete=models.CASCADE, to="example_app.intmodel"
+            ),
+        )
+
+        operation.state_forwards(self.app_label, new_state)
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, from_state=project_state, to_state=new_state
+                )
+        assert len(queries) == 6
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_nullfkfieldmodel'::regclass
+                AND attname = 'fk_id'
+                AND attnotnull IS TRUE;
+        """)
+        assert queries[1]["sql"] == dedent("""
+            SELECT conname
+            FROM pg_catalog.pg_constraint
+            WHERE conname = 'example_ap_fk_id_9fd70957e5';
+        """)
+        assert queries[2]["sql"] == dedent("""
+            ALTER TABLE "example_app_nullfkfieldmodel"
+            ADD CONSTRAINT "example_ap_fk_id_9fd70957e5"
+            CHECK ("fk_id" IS NOT NULL) NOT VALID;
+        """)
+        assert queries[3]["sql"] == dedent("""
+            ALTER TABLE "example_app_nullfkfieldmodel"
+            VALIDATE CONSTRAINT "example_ap_fk_id_9fd70957e5";
+        """)
+        assert queries[4]["sql"] == dedent("""
+            ALTER TABLE "example_app_nullfkfieldmodel"
+            ALTER COLUMN "fk_id"
+            SET NOT NULL;
+        """)
+        assert queries[5]["sql"] == dedent("""
+            ALTER TABLE "example_app_nullfkfieldmodel"
+            DROP CONSTRAINT "example_ap_fk_id_9fd70957e5";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, from_state=new_state, to_state=project_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_nullfkfieldmodel'::regclass
+                AND attname = 'fk_id'
+                AND attnotnull IS TRUE;
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_nullfkfieldmodel"
+            ALTER COLUMN "fk_id"
+            DROP NOT NULL;
+        """)
+
+        # Reversing again does nothing apart from checking the field is already
+        # nullable.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as second_reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, from_state=new_state, to_state=project_state
+                )
+        assert len(second_reverse_queries) == 1
+
+        assert second_reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_nullfkfieldmodel'::regclass
+                AND attname = 'fk_id'
+                AND attnotnull IS TRUE;
+        """)
 
     @pytest.mark.django_db(transaction=True)
     def test_operation(self):

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -54,6 +54,10 @@ class NullIntFieldModel(models.Model):
     int_field = models.IntegerField(null=True)
 
 
+class NullFKFieldModel(models.Model):
+    fk = models.ForeignKey(IntModel, null=True, on_delete=models.CASCADE)
+
+
 class NotNullIntFieldModel(models.Model):
     # null=False is the default, but we set it here for clarity.
     int_field = models.IntegerField(null=False)


### PR DESCRIPTION
Changes:

    Fix SaferAlterFieldSetNotNull for custom-named fields
    
    Prior to this change, this operation didn't work for fields that had
    column names in the database that didn't match their names (such as
    ForeignKey fields, which have an "_id" suffix).
    
    This commit changes that by obtaining the column name from the model's
    meta class instead.

