### PR TITLE
Fix `SaferAddFieldForeignKey` when field name != column name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- `SaferAddFieldForeignKey` did not work correctly when the primary key field
+  on the referred table had a column name that different from the field name.
+
 ## [0.1.18] - 2025-02-11
 
 ### Fixed

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -1382,6 +1382,7 @@ class ForeignKeyManager(base_operations.Operation):
     def _alter_table_add_not_valid_fk(self) -> None:
         remote_model = self._get_remote_model()
         remote_pk_field = self._get_remote_pk_field()
+        referred_column_name = remote_pk_field.db_column or remote_pk_field.name
         self.schema_editor.execute(
             psycopg_sql.SQL(ConstraintQueries.ALTER_TABLE_ADD_NOT_VALID_FK)
             .format(
@@ -1389,7 +1390,7 @@ class ForeignKeyManager(base_operations.Operation):
                 column_name=psycopg_sql.Identifier(self.column_name),
                 constraint_name=psycopg_sql.Identifier(self.constraint_name),
                 referred_table_name=psycopg_sql.Identifier(remote_model._meta.db_table),
-                referred_column_name=psycopg_sql.Identifier(remote_pk_field.name),
+                referred_column_name=psycopg_sql.Identifier(referred_column_name),
             )
             .as_string(self.schema_editor.connection.connection)
         )

--- a/tests/django_pg_migration_tools/test_operations.py
+++ b/tests/django_pg_migration_tools/test_operations.py
@@ -20,6 +20,7 @@ from tests.example_app.models import (
     CharIDModel,
     CharModel,
     IntModel,
+    IntModelWithExplicitPK,
     ModelWithCheckConstraint,
     ModelWithForeignKey,
     NotNullIntFieldModel,
@@ -3269,6 +3270,109 @@ class TestSaferAddFieldForeignKey:
         assert reverse_queries[1]["sql"] == dedent("""
             ALTER TABLE "example_app_intmodel"
             DROP COLUMN "char_model_field_id";
+        """)
+
+    @pytest.mark.django_db(transaction=True)
+    def test_operation_when_related_model_has_explicit_pk_field(self):
+        with connection.cursor() as cursor:
+            # Set the lock_timeout to check it has been returned to
+            # its original value once the fk index creation is completed.
+            cursor.execute(_SET_LOCK_TIMEOUT)
+
+        project_state = ProjectState()
+        project_state.add_model(ModelState.from_model(IntModel))
+        project_state.add_model(ModelState.from_model(IntModelWithExplicitPK))
+        new_state = project_state.clone()
+        operation = operations.SaferAddFieldForeignKey(
+            model_name="intmodel",
+            name="other_int_model_field",
+            field=models.ForeignKey(
+                IntModelWithExplicitPK, null=True, on_delete=models.CASCADE
+            ),
+        )
+
+        operation.state_forwards(self.app_label, new_state)
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as queries:
+                operation.database_forwards(
+                    self.app_label, editor, from_state=project_state, to_state=new_state
+                )
+        assert len(queries) == 9
+
+        assert queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'other_int_model_field_id';
+        """)
+        assert queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD COLUMN IF NOT EXISTS "other_int_model_field_id"
+            integer NULL;
+        """)
+        assert queries[2]["sql"] == "SHOW lock_timeout;"
+        assert queries[3]["sql"] == "SET lock_timeout = '0';"
+        assert queries[4]["sql"] == dedent("""
+            SELECT relname
+            FROM pg_class, pg_index
+            WHERE (
+                pg_index.indisvalid = false
+                AND pg_index.indexrelid = pg_class.oid
+                AND relname = 'intmodel_other_int_model_field_id_idx'
+            );
+            """)
+        assert (
+            queries[5]["sql"]
+            == 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "intmodel_other_int_model_field_id_idx" ON "example_app_intmodel" ("other_int_model_field_id");'
+        )
+        assert queries[6]["sql"] == "SET lock_timeout = '1s';"
+        assert queries[7]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            ADD CONSTRAINT "example_app_intmodel_other_int_model_field_id_fk" FOREIGN KEY ("other_int_model_field_id")
+            REFERENCES "example_app_intmodelwithexplicitpk" ("id32")
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+        """)
+        assert queries[8]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            VALIDATE CONSTRAINT "example_app_intmodel_other_int_model_field_id_fk";
+        """)
+
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, from_state=new_state, to_state=project_state
+                )
+        assert len(reverse_queries) == 2
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'other_int_model_field_id';
+        """)
+        assert reverse_queries[1]["sql"] == dedent("""
+            ALTER TABLE "example_app_intmodel"
+            DROP COLUMN "other_int_model_field_id";
+        """)
+
+        # Reversing again does nothing apart from checking the field doesn't
+        # exist anymore. This check the reverse migration is idempotent.
+        with connection.schema_editor(atomic=False, collect_sql=False) as editor:
+            with utils.CaptureQueriesContext(connection) as second_reverse_queries:
+                operation.database_backwards(
+                    self.app_label, editor, from_state=new_state, to_state=project_state
+                )
+        assert len(second_reverse_queries) == 1
+
+        assert reverse_queries[0]["sql"] == dedent("""
+            SELECT 1
+            FROM pg_catalog.pg_attribute
+            WHERE
+                attrelid = 'example_app_intmodel'::regclass
+                AND attname = 'other_int_model_field_id';
         """)
 
 

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -22,6 +22,10 @@ class IntModel(models.Model):
     int_field = models.IntegerField(default=0)
 
 
+class IntModelWithExplicitPK(models.Model):
+    explicit_pk = models.IntegerField(primary_key=True, db_column="id32")
+
+
 class ModelWithForeignKey(models.Model):
     fk = models.ForeignKey(IntModel, null=True, on_delete=models.CASCADE)
 


### PR DESCRIPTION
Prior to this change, this operation didn't work for fields that referred to tables where the primary key field had a column name that differed from the field name.

This commit fixes that by referring to the column name instead of the field name.