### PR TITLE
Bugfix: drop unique constraint sqlmigrate is noop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
-_No notable unreleased changes_
+### Fixed
+
+- `SaferRemoveUniqueConstraint` now produces the best-effort plan for a migration that would be
+  performed if the constraint wanting to be removed does in fact exist when running `sqlmigrate`.
+  Previously, this would act as if the constraint did not exist is using `sqlmigrate`.
+- `SaferAddUniqueConstraint` now produces a backwards plan as if the constraint has already been
+   created when running `sqlmigrate`.
 
 ## [0.1.19] - 2025-04-04
 

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -506,7 +506,7 @@ class SafeConstraintOperationManager(base_operations.Operation):
             )
             return
 
-        if not self._constraint_exists(schema_editor, constraint):
+        if not self._constraint_exists(schema_editor, constraint, collect_default=True):
             # Nothing to delete.
             return
 
@@ -591,7 +591,9 @@ class SafeConstraintOperationManager(base_operations.Operation):
         constraint: models.UniqueConstraint,
         raise_if_exists: bool,
     ) -> bool:
-        constraint_exists = self._constraint_exists(schema_editor, constraint)
+        constraint_exists = self._constraint_exists(
+            schema_editor, constraint, collect_default=False
+        )
         if raise_if_exists and constraint_exists:
             raise ConstraintAlreadyExists(
                 f"Cannot create a constraint with the name "
@@ -619,7 +621,7 @@ class SafeConstraintOperationManager(base_operations.Operation):
         self,
         schema_editor: base_schema.BaseDatabaseSchemaEditor,
         constraint: models.UniqueConstraint | models.CheckConstraint,
-        collect_default: bool = False,
+        collect_default: bool,
     ) -> bool:
         return _run_introspection_query(
             schema_editor,


### PR DESCRIPTION
Change `collect_default` on constraint existing checks to require an explicit value rather than defaulting to false. This was causing the operation to say that the constraint did not exist and could not generate any SQL when the migration to drop a constraint was in collect only mode.

The value needs to be set to True when dropping constraints so that the SQL for what would happen if a constraint exists is shown (as the alternative is not useful).