### PR TITLE
Handle scenario where unique constraint with expression(s) is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
-_No notable unreleased changes_
+### Fixed
+
+- Fixed a bug where `SaferAddUniqueConstraint` and `SaferRemoveUniqueConstraint` would
+  accept unique constraints with expressions on them, but produce invalid SQL. This is
+  now handled in the same way as unique constraints with conditions, as unique indexes,
+  as per the equivalent Django `AddConstraint` and `RemoveConstraint` operations.
 
 ## [0.1.20] - 2025-06-19
 

--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -412,12 +412,12 @@ class SafeConstraintOperationManager(base_operations.Operation):
 
         index = self._get_index_for_constraint(constraint)
 
-        if constraint.condition is not None:
+        if (constraint.condition is not None) or constraint.expressions:
             """
-            Unique constraints with conditions do not exist in postgres.
+            Unique constraints with conditions/expressions do not exist in postgres.
 
-            As of writing Django handles these as unique indexes with conditions only
-            in the auto generated operation, so we only create the index and finish here
+            As of writing Django handles these as unique indexes with conditions/expressions
+            only in the auto generated operation, so we only create the index and finish here
             """
             SafeIndexOperationManager().safer_create_index(
                 app_label=app_label,
@@ -491,9 +491,9 @@ class SafeConstraintOperationManager(base_operations.Operation):
         if not self.allow_migrate_model(schema_editor.connection.alias, model):
             return
 
-        if constraint.condition is not None:
-            # If condition is present on the constraint, it would have been created
-            # as an index instead, so index is instead removed
+        if (constraint.condition is not None) or constraint.expressions:
+            # If condition/expressions are present on the constraint, it would have
+            # been created as an index instead, so index is instead removed
             index = self._get_index_for_constraint(constraint)
 
             SafeIndexOperationManager().safer_drop_index(

--- a/tests/example_app/models.py
+++ b/tests/example_app/models.py
@@ -1,5 +1,6 @@
 import django
 from django.db import models
+from django.db.models import functions
 
 
 def get_check_constraint(condition: models.Q, name: str) -> models.CheckConstraint:
@@ -40,16 +41,35 @@ class CharModel(models.Model):
         )
 
 
-class AnotherCharModel(models.Model):
+class UniqueConditionCharModel(models.Model):
     char_field = models.CharField(default="char")
 
     class Meta:
-        indexes = (models.Index(fields=["char_field"], name="another_char_field_idx"),)
+        indexes = (
+            models.Index(fields=["char_field"], name="unique_condition_char_field_idx"),
+        )
         constraints = (
             models.UniqueConstraint(
                 fields=["char_field"],
                 name="unique_char_field_with_condition",
                 condition=models.Q(char_field__in=["c", "something"]),
+            ),
+        )
+
+
+class UniqueExpressionCharModel(models.Model):
+    char_field = models.CharField(default="char")
+
+    class Meta:
+        indexes = (
+            models.Index(
+                fields=["char_field"], name="unique_expression_char_field_idx"
+            ),
+        )
+        constraints = (
+            models.UniqueConstraint(
+                functions.Lower("char_field"),
+                name="unique_char_field_with_expression",
             ),
         )
 


### PR DESCRIPTION
This PR fixes a bug where a unique constraint with expressions produces invalid SQL when used with `SaferAddUniqueConstraint` and `SaferRemoveUniqueConstraint`.

These changes are based on a [previous PR](https://github.com/kraken-tech/django-pg-migration-tools/pull/42) which solved a similar issue for unique constraints with conditions.