### PR TITLE
Fix message behind ConstraintAlreadyExists exception

### DIFF
--- a/src/django_pg_migration_tools/operations.py
+++ b/src/django_pg_migration_tools/operations.py
@@ -600,7 +600,7 @@ class SafeConstraintOperationManager(base_operations.Operation):
                 f"{constraint.name} because a constraint of the same "
                 f"name already exists. If you want to skip this operation "
                 f"when the constraint already exists, run the operation "
-                f"with the flag `skip_if_exists=True`."
+                f"with the flag `raise_if_exists=False`."
             )
         # We can't re-create a constraint that already exists because the
         # ALTER TABLE ... ADD CONSTRAINT is not idempotent.


### PR DESCRIPTION
The message in ConstraintAlreadyExists was following the old argument skip_if_exists - which doesn't exist in the current master. This commit fixes that message to use raise_if_exists instead.

The behaviour of this is tested on:
- test_do_nothing_when_asked_not_to_raise_when_constraint_exists
- test_raises_if_constraint_already_exists

In TestSaferAddUniqueConstraint.