### PR TITLE
Add support for `nulls_distinct=False` in unique constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 
 ## [Unreleased]
 
-_No notable unreleased changes_
+- Fixed a bug where a unique constraint with `nulls_distinct=False` was created
+  without "NULLS NOT DISTINCT" by `SaferAddUniqueConstraint`.
+- Fixed a bug where a unique constraint with `nulls_distinct=False` resulted in
+  invalid SQL when `SaferAddUniqueConstraint` was used with PostgreSQL 14.x or
+  earlier (which does not support "NULLS NOT DISTINCT"). The operation will now
+  raise a `ConstraintNotSupported` exception instead.
 
 ## [0.1.25] - 2026-02-24
 


### PR DESCRIPTION
A migration with the `SaferAddUniqueConstraint` operation for a constraint using `nulls_distinct=False` failed with a syntax error when attempted against Postgres version 14.x:

```
syntax error at or near "None"
LINE 1: ...mjobs/management/commands/migrate.py', line=28 */ None UNIQU...
                                                             ^
```

The ultimate cause was attempting to create a unique constraint with "NULLS NOT DISTINCT", which isn't supported on Postgres until version 15. And in the course of investigating that issue, we also noticed that even on Postgres 15 and higher, the constraint is created, but without "NULLS NOT DISTINCT".

This PR:

- adds support for creating unique constraints with `nulls_distinct=False`
- adds better error handling for when attempting to create such constraints on Postgres versions that don't support them (version 14 and earlier)

Note that this PR also introduces 3 missed lines in the code coverage of test_operations.py; it's unavoidable since code coverage is run with Postgres 16, and those lines are only exercised with Postgres 14 and below.